### PR TITLE
fix: remove prettier CR error for non-mac users

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   // wider line length for better TSX readability
   printWidth: 120,
+  endOfLine: "auto",
 };


### PR DESCRIPTION
## Developer: Ida Voong

Closes #N/A

### Pull Request Summary

Mac users endOfLine is different from microsoft's endOfLine. Prettier highlights this as an error or every line.

### Modifications

- `prettier.config.js`

### Testing Considerations

- check if you get the error on your IDE

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="756" height="298" alt="image" src="https://github.com/user-attachments/assets/10839c96-6384-427b-a706-7d539a6eecd6" />

<img width="845" height="341" alt="image" src="https://github.com/user-attachments/assets/8251e03d-3b55-438b-b3a6-beab815756ea" />
