### PR TITLE
(Updated) Menu Planning Monthly View: Recipe Card + Warning Quota Logo/Icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 next-env.d.ts
 
 .env
+
+.clerk/

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -5,10 +5,12 @@ import WeekView from "@/components/menuPlanning/WeekView";
 import RecipeDatabase from "@/components/menuPlanning/RecipeDatabase";
 import CurrentDateButton from "@/components/CurrentDateButton";
 import RecipeDailyCard from "@/components/RecipeDailyCard";
+import RecipeMonthlyCard from "@/components/RecipeMonthlyCard";
 import { ChevronLeft, ChevronRight, ArrowDownToLine } from "lucide-react";
 import { CategoryValue, EMPTY_FILTERS, SortOption } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import { first } from "firebase/firestore/pipelines";
+import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
 
 const today = new Date();
 
@@ -168,7 +170,22 @@ export default function MenuPlanning() {
             </div>
           </div>
 
-          {calendarView === "Month" && <div>Month view coming soon!</div>}
+          {calendarView === "Month" && (
+            // dummy data
+            <div className="space-y-2">
+              <div>Month view coming soon!</div>
+              <div className="w-40">
+                <RecipeMonthlyCard name="Chicken Tikka Masala" tags={["Entree"]} />
+              </div>
+              <div className="w-40">
+                <RecipeMonthlyCard name="Mango Cup" tags={["Fruit"]} />
+              </div>
+              <div className="w-40">
+                <RecipeMonthlyCard name="Brown Rice" tags={["Sides"]} />
+              </div>
+              <WarningQuotaMonthly />
+            </div>
+          )}
           {calendarView === "Week" && <WeekView dateToday={today} weekDates={weekDates} />}
           {calendarView === "Day" && (
             // dummy data

--- a/src/components/RecipeMonthlyCard.tsx
+++ b/src/components/RecipeMonthlyCard.tsx
@@ -1,0 +1,28 @@
+import { GripVertical } from "lucide-react";
+
+export type RecipeCardProps = {
+  name: string;
+  tags?: string[];
+};
+
+const TAG_STYLES: Record<string, string> = {
+  Combo: "bg-combo-500 text-combo-900",
+  Sides: "bg-sides-500 text-black",
+  Fruit: "bg-fruit-500 text-fruit-900",
+  Entree: "bg-yellow-900 text-white",
+  Entrée: "bg-yellow-900 text-white",
+  fallback: "bg-gray-100 text-gray-700",
+};
+
+export default function RecipeMonthlyCard({ name, tags = [] }: RecipeCardProps) {
+  const primaryTag = tags[0];
+  const tagStyle = (primaryTag && TAG_STYLES[primaryTag]) ?? TAG_STYLES.fallback;
+  return (
+    <div
+      className={` ${tagStyle} flex justify-between items-center gap-1 rounded-md py-0.5 px-2 transition hover:shadow-md cursor-pointer min-w-0`}
+    >
+      <h3 className="truncate">{name}</h3>
+      <GripVertical size={15} strokeWidth={1.7} className="cursor-move shrink-0" />
+    </div>
+  );
+}

--- a/src/components/WarningQuotaMonthly.tsx
+++ b/src/components/WarningQuotaMonthly.tsx
@@ -1,0 +1,22 @@
+export default function WarningQuotaMonthly() {
+  return (
+    <div className="group relative flex w-6 h-6 justify-center items-center rounded-md font-bold bg-red-600 text-white">
+      <h1>!</h1>
+
+      <div className="pointer-events-none invisible absolute bottom-full left-1/2 mb-2 w-40 -translate-x-1/2 opacity-0 transition-all group-hover:visible group-hover:opacity-100">
+        <div className="absolute left-1/2 transform -ml-1 -translate-x-1/2 mb-1 h-25 w-35 px-4 py-3 rounded-md bg-red-600 opacity-0 group-hover:opacity-100 transition-opacity"></div>
+
+        <div className="relative left-1/2 -translate-x-1/2 mb-1 h-25 w-35 px-3 py-4 rounded-md bg-rose-100 text-black text-s font-normal opacity-0 group-hover:opacity-100 transition-opacity">
+          <div className="flex items-center gap-2">
+            <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-red-600 text-lg font-bold text-white">
+              !
+            </div>
+            <h2 className="text-xl font-semibold">Warning</h2>
+          </div>
+          <p className="text-md text-gray-900 leading-tight">Meal quota not met</p>
+          <div className="absolute top-full left-1/2 -translate-x-1/2 border-t-8 border-x-transparent border-t-rose-50"></div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Developer: Haixin Huang

Closes #117 

### Pull Request Summary

- Created components for meal planning monthly view, including recipe card and warning icon + pop-up.

### Modifications

- menuPlanning/page.tsx - example recipe card components
- RecipeCardMonthly.tsx - implemented recipe card for monthly view
- WarningQuotaMonthly.tsx - implemented warning icon + pop-up for monthly view

### Testing Considerations

- Navigate to the Menu Planning page. On the Month view, hover over the warning icon to make sure that the pop-up message becomes visible.
- See the Figma file to make sure that the components match the hi-fi design.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="255" height="215" alt="image" src="https://github.com/user-attachments/assets/ff038303-a85e-4a28-a8e6-97b75d2cdb6c" />

https://github.com/user-attachments/assets/c9949f46-b958-4713-85f8-9c2d61ec8f02

