### PR TITLE
107: export monthly menu as spreadsheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@headlessui/react": "^2.2.9",
         "@tailwindcss/postcss": "^4.1.18",
         "firebase": "^12.12.0",
+        "json-as-xlsx": "^2.5.6",
         "lucide-react": "^0.563.0",
         "mongoose": "^8",
         "next": "^16.2.3",
@@ -116,7 +117,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -936,7 +936,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -960,7 +959,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -999,6 +997,17 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@e965/xlsx": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@e965/xlsx/-/xlsx-0.20.3.tgz",
+      "integrity": "sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w==",
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1158,7 +1167,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
       "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -1225,7 +1233,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
       "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
@@ -1695,7 +1702,6 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3684,7 +3690,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3941,7 +3946,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3952,7 +3956,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3963,7 +3966,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4059,7 +4061,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4579,7 +4580,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5125,7 +5125,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6144,7 +6143,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6229,7 +6227,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6328,7 +6325,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8256,7 +8252,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9240,7 +9235,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9286,6 +9280,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-as-xlsx": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/json-as-xlsx/-/json-as-xlsx-2.5.6.tgz",
+      "integrity": "sha512-z7phlB+VgS9wZv2N4SBKlguC3C7uauSj2PYSZICCrPaiu1lu8zkCpzZ4sOHWi0/3Je0CJl87q+J+3mpZbxpOew==",
+      "dependencies": {
+        "@e965/xlsx": "^0.20.0"
       }
     },
     "node_modules/json-buffer": {
@@ -11255,7 +11257,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11402,7 +11403,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11415,7 +11415,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12709,7 +12708,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12880,7 +12878,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13081,7 +13078,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@headlessui/react": "^2.2.9",
     "@tailwindcss/postcss": "^4.1.18",
     "firebase": "^12.12.0",
+    "json-as-xlsx": "^2.5.6",
     "lucide-react": "^0.563.0",
     "mongoose": "^8",
     "next": "^16.2.3",

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@/database/db";
+import Calendar from "@/database/CalendarSchema";
+
+export async function GET(req: NextRequest) {
+  try {
+    await connectDB();
+    const searchParams = req.nextUrl.searchParams;
+
+    const year = searchParams.get("year");
+    const month = searchParams.get("month")?.padStart(2, "0");
+
+    if (year && month) {
+      const yearMonth = `${year}${month}`;
+      const result = await Calendar.find({ _id: { $regex: `^${yearMonth}` } })
+        .populate("entrees")
+        .populate("fruits")
+        .populate("sides")
+        .exec();
+      return NextResponse.json(result);
+    }
+
+    const result = await Calendar.find().exec();
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching calendar data:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -1,60 +1,192 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import WeekView from "@/components/menuPlanning/WeekView";
 import RecipeDatabase from "@/components/menuPlanning/RecipeDatabase";
 import CurrentDateButton from "@/components/CurrentDateButton";
 import RecipeDailyCard from "@/components/RecipeDailyCard";
 import RecipeMonthlyCard from "@/components/RecipeMonthlyCard";
 import { ChevronLeft, ChevronRight, ArrowDownToLine } from "lucide-react";
-import { CategoryValue, EMPTY_FILTERS, SortOption } from "@/lib/types";
+import { CategoryValue, EMPTY_FILTERS, Recipe, SortOption } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import { first } from "firebase/firestore/pipelines";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
+import xlsx, { IContent, IJsonSheet } from "json-as-xlsx";
+import { Label } from "@headlessui/react";
+
+interface CalendarDay {
+  _id: string;
+  entrees: Recipe[];
+  fruits: Recipe[];
+  sides: Recipe[];
+}
 
 const today = new Date();
 
-const getOffsetDate = (date: Date, offset: number) => {
+const getOffsetDate = (date: Date, offset: number, view: "Month" | "Week" | "Day") => {
   const newDate = new Date(date);
-  newDate.setDate(date.getDate() + offset * 7);
+
+  if (view === "Day") {
+    newDate.setDate(date.getDate() + offset);
+  } else if (view === "Week") {
+    newDate.setDate(date.getDate() + offset * 7);
+  } else if (view === "Month") {
+    newDate.setMonth(date.getMonth() + offset);
+  }
+
   return newDate;
 };
 
-const getCurrentWeekDates = (today: Date) => {
-  const dayOfWeek = today.getDay();
-  const startOfWeek = new Date(today);
-  startOfWeek.setDate(today.getDate() - dayOfWeek + 1);
+const getCurrentViewDates = (today: Date, view: "Month" | "Week" | "Day") => {
+  if (view === "Day") {
+    return [today];
+  } else if (view === "Week") {
+    const dayOfWeek = today.getDay(); // 0 (Sun) - 6 (Sat)
+    const startOfWeek = new Date(today);
+    startOfWeek.setDate(today.getDate() - dayOfWeek + 1); // start from Monday
+    return Array.from({ length: 5 }, (_, i) => {
+      const date = new Date(startOfWeek);
+      date.setDate(startOfWeek.getDate() + i);
+      return date;
+    });
+  } else if (view === "Month") {
+    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
 
-  return Array.from({ length: 5 }, (_, i) => {
-    const date = new Date(startOfWeek);
-    date.setDate(startOfWeek.getDate() + i);
-    return date;
-  });
-};
+    let startDay: Date;
+    startDay = new Date(startOfMonth);
 
-const getOffsetMonthDate = (date: Date, offset: number) => {
-  const newDate = new Date(date);
-  newDate.setMonth(date.getMonth() + offset);
-  return newDate;
-};
+    if (startDay.getDay() !== 0) {
+      const prevMonthStartDay =
+        new Date(today.getFullYear(), today.getMonth(), 0).getDate() - startOfMonth.getDay() + 1;
+      const prevMonth = today.getMonth() - 1;
+      const prevMonthYear = prevMonth < 0 ? today.getFullYear() - 1 : today.getFullYear();
+      const prevMonthDate = new Date(prevMonthYear, (prevMonth + 12) % 12, prevMonthStartDay);
+      startDay = new Date(prevMonthDate);
+    }
 
-const getOffsetDayDate = (date: Date, offset: number) => {
-  const newDate = new Date(date);
-  newDate.setDate(date.getDate() + offset);
-  return newDate;
+    return Array.from({ length: 35 }, (_, i) => {
+      const date = new Date(startDay);
+      date.setDate(startDay.getDate() + i);
+      return date;
+    });
+  }
+  return [];
 };
 
 export default function MenuPlanning() {
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("createdDate");
-  const [dayOffset, setDayOffset] = useState(0);
-  const [weekOffset, setWeekOffset] = useState(0);
-  const [monthOffset, setMonthOffset] = useState(0);
-  const monthDate = getOffsetMonthDate(today, monthOffset);
   const [calendarView, setCalendarView] = useState<"Month" | "Week" | "Day">("Week");
+  const [datesOffset, setDatesOffset] = useState(0);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set());
+  const viewDates = getCurrentViewDates(getOffsetDate(today, datesOffset, calendarView), calendarView); // Day: 1 day, Week: 5 days, Month: 35 days (including prev/next month)
 
-  const weekDates = getCurrentWeekDates(getOffsetDate(today, weekOffset));
+  const downloadMonthlyMenu = async () => {
+    let currentMonth: number;
+    let currentYear: number;
+    if (calendarView === "Day") {
+      currentMonth = viewDates[0].getMonth();
+      currentYear = viewDates[0].getFullYear();
+    } else if (calendarView === "Week") {
+      currentMonth = viewDates[0].getMonth();
+      currentYear = viewDates[0].getFullYear();
+    } else {
+      currentMonth = viewDates[10].getMonth();
+      currentYear = viewDates[10].getFullYear();
+    }
+
+    try {
+      const res = await fetch(`/api/calendar?year=${currentYear}&month=${currentMonth + 1}`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+      const dates = await res.json();
+
+      const data: IContent[] = [];
+
+      dates.forEach((date: CalendarDay) => {
+        const formattedDate = `${date._id.slice(0, 4)}-${date._id.slice(4, 6)}-${date._id.slice(6, 8)}`;
+        const allItems = [...(date.entrees || []), ...(date.fruits || []), ...(date.sides || [])];
+
+        // Calculate totals
+        const totals = allItems.reduce(
+          (acc, item) => {
+            acc.calorie += item.nutritional_info.calories || 0;
+            acc.protein += item.nutritional_info.protein || 0;
+            acc.fat += item.nutritional_info.fat || 0;
+            acc.carbs += item.nutritional_info.carbs || 0;
+            acc.fiber += item.nutritional_info.fiber || 0;
+            acc.sodium += item.nutritional_info.sodium || 0;
+            return acc;
+          },
+          {
+            name: formattedDate,
+            serving: "",
+            calorie: 0,
+            protein: 0,
+            fat: 0,
+            carbs: 0,
+            fiber: 0,
+            sodium: 0,
+          },
+        );
+        data.push(totals);
+
+        // Push individual items
+        const pushItems = (items: Recipe[], type: string) => {
+          items?.forEach((item) => {
+            data.push({
+              name: item.name,
+              serving: item.serving,
+              calorie: item.nutritional_info.calories,
+              protein: item.nutritional_info.protein,
+              fat: item.nutritional_info.fat,
+              carbs: item.nutritional_info.carbs,
+              fiber: item.nutritional_info.fiber,
+              sodium: item.nutritional_info.sodium,
+            });
+          });
+        };
+        pushItems(date.entrees, "Entree");
+        pushItems(date.fruits, "Fruit");
+        pushItems(date.sides, "Side");
+
+        // spacing
+        data.push({
+          name: "",
+          serving: "",
+          calorie: "",
+          protein: "",
+          fat: "",
+          carbs: "",
+          fiber: "",
+          sodium: "",
+        });
+      });
+
+      const sheetData: IJsonSheet[] = [
+        {
+          sheet: "Menu",
+          columns: [
+            { label: "Item Name", value: "name" },
+            { label: "Serving", value: "serving" },
+            { label: "Cals (kcal)", value: "calorie" },
+            { label: "Prot (g)", value: "protein" },
+            { label: "Fat (g)", value: "fat" },
+            { label: "Carbs (g)", value: "carbs" },
+            { label: "Fiber (g)", value: "fiber" },
+            { label: "Sodium (mg)", value: "sodium" },
+          ],
+          content: data,
+        },
+      ];
+
+      const settings = { fileName: `${currentYear}_${(currentMonth + 1).toString().padStart(2, "0")}_MTC_Menu.xlsx` };
+      xlsx(sheetData, settings);
+    } catch (error) {
+      console.error("Error downloading monthly menu:", error);
+    }
+  };
 
   const toggleCategory = (category: CategoryValue) => {
     setSelectedCategories((prev) => {
@@ -82,21 +214,9 @@ export default function MenuPlanning() {
     sortBy,
   });
 
-  const handleNavigate = (direction: "prev" | "next") => {
-    if (calendarView === "Week") {
-      setWeekOffset((prev) => prev + (direction === "prev" ? -1 : 1));
-    } else if (calendarView === "Month") {
-      setMonthOffset((prev) => prev + (direction === "prev" ? -1 : 1));
-    } else if (calendarView === "Day") {
-      setDayOffset((prev) => prev + (direction === "prev" ? -1 : 1));
-    }
-  };
-
-  const handleReset = () => {
-    setWeekOffset(0);
-    setMonthOffset(0);
-    setDayOffset(0);
-  };
+  useEffect(() => {
+    setDatesOffset(0);
+  }, [calendarView]);
 
   return (
     <main className="flex flex-row">
@@ -104,41 +224,20 @@ export default function MenuPlanning() {
         <div className="flex flex-col h-full w-210">
           <div className="flex justify-between items-center mt-4">
             <div className="flex items-center justify-center gap-2">
-              <CurrentDateButton onClick={() => handleReset()} />
-              <button className="cursor-pointer" onClick={() => handleNavigate("prev")}>
+              <CurrentDateButton onClick={() => setDatesOffset(0)} />
+              <button className="cursor-pointer" onClick={() => setDatesOffset(datesOffset - 1)}>
                 <ChevronLeft size={20} strokeWidth={2.5} />
               </button>
               <span className="font-bold text-xl">
-                {(calendarView === "Week" &&
-                  (() => {
-                    const firstDay = weekDates[0];
-                    const lastDay = weekDates[4];
-
-                    const startMonth = firstDay.toLocaleDateString(undefined, { month: "short" });
-                    const endMonth = lastDay.toLocaleDateString(undefined, { month: "short" });
-
-                    if (startMonth !== endMonth) {
-                      return `${startMonth} ${firstDay.getDate()} - ${endMonth} ${lastDay.getDate()}`;
-                    }
-                    return `${startMonth} ${firstDay.getDate()} - ${lastDay.getDate()}`;
-                  })()) ||
-                  (calendarView === "Month" &&
-                    (() => {
-                      const month = monthDate.toLocaleDateString(undefined, { month: "short" });
-                      const year = monthDate.getFullYear();
-                      return `${month} ${year}`;
-                    })()) ||
-                  (calendarView === "Day" &&
-                    (() => {
-                      const currentDay = getOffsetDayDate(today, dayOffset);
-                      const dayOfWeek = currentDay.toLocaleDateString(undefined, { weekday: "long" });
-                      const day = currentDay.getDate();
-                      const month = currentDay.toLocaleDateString(undefined, { month: "long" });
-                      const year = currentDay.getFullYear();
-                      return `${dayOfWeek}, ${month} ${day}, ${year}`;
-                    })())}
+                {calendarView === "Day" &&
+                  `${viewDates[0].toLocaleDateString(undefined, { weekday: "long", day: "numeric", month: "long", year: "numeric" })}`}
+                {calendarView === "Week" &&
+                  `${viewDates[0].toLocaleDateString(undefined, { month: "long" })} ${viewDates[0].getDate()} - ${viewDates[4].toLocaleDateString(undefined, { month: "long" })} ${viewDates[4].getDate()}`}
+                {/* use 10th date instead of 0 to guarantee a date in the current month */}
+                {calendarView === "Month" &&
+                  viewDates[10].toLocaleDateString(undefined, { month: "long", year: "numeric" })}
               </span>
-              <button className="cursor-pointer" onClick={() => handleNavigate("next")}>
+              <button className="cursor-pointer" onClick={() => setDatesOffset(datesOffset + 1)}>
                 <ChevronRight size={20} strokeWidth={2.5} />
               </button>
             </div>
@@ -165,7 +264,13 @@ export default function MenuPlanning() {
                 </button>
               </div>
               <span className="bg-radish-900 rounded-md p-2 ml-2">
-                <ArrowDownToLine className="cursor-pointer" color="white" size={20} strokeWidth={2.5} />
+                <ArrowDownToLine
+                  className="cursor-pointer"
+                  color="white"
+                  size={20}
+                  strokeWidth={2.5}
+                  onClick={downloadMonthlyMenu}
+                />
               </span>
             </div>
           </div>
@@ -186,7 +291,7 @@ export default function MenuPlanning() {
               <WarningQuotaMonthly />
             </div>
           )}
-          {calendarView === "Week" && <WeekView dateToday={today} weekDates={weekDates} />}
+          {calendarView === "Week" && <WeekView dateToday={today} weekDates={viewDates} />}
           {calendarView === "Day" && (
             // dummy data
             <div>


### PR DESCRIPTION
## Developer: Ida Voong

Closes #107 

### Pull Request Summary

- implement backend for downloading monthly menu as a spreadsheet

### Modifications

- `app/api/calendar/route.ts`: GET req for calendar entries relevant to the month
- `app/menuPlanning/page.tsx`: fetching, formatting data, then downloading as spreadsheet

### Testing Considerations

- clicking on download button should download monthly menu

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1049" height="596" alt="image" src="https://github.com/user-attachments/assets/f447316d-c1b6-4a75-8133-dcf6de2d7413" />
