### PR TITLE
Implement drag and drop for daily view

### DIFF
--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect, useCallback } from "react";
 import { DndContext, DragEndEvent, DragStartEvent, DragOverlay } from "@dnd-kit/core";
 import WeekView from "@/components/menuPlanning/WeekView";
 import RecipeDatabase from "@/components/menuPlanning/RecipeDatabase";
-import DailyNutritionSummary from "@/components/menuPlanning/DailyNutritionSummary";
 import WeeklyNutritionQuota from "@/components/menuPlanning/WeeklyNutritionQuota";
 import DraggableRecipeCard from "@/components/menuPlanning/DraggableRecipeCard";
+import DayView from "@/components/menuPlanning/DayView";
 import CurrentDateButton from "@/components/CurrentDateButton";
-import RecipeDailyCard from "@/components/RecipeDailyCard";
 import RecipeMonthlyCard from "@/components/RecipeMonthlyCard";
 import { ChevronLeft, ChevronRight, ArrowDownToLine } from "lucide-react";
 import { CategoryValue, EMPTY_FILTERS, Nutrition, Recipe, SortOption, Combo } from "@/lib/types";
@@ -51,37 +50,6 @@ const SAMPLE_RECIPES: Recipe[] = [
     filters: ["Sides"],
     isDraft: false,
     nutritional_info: { calories: 200, protein: 0, fat: 0, carbs: 0, fiber: 0, sodium: 0 },
-  },
-];
-
-// Dummy recipe data for Day view (mock until backend integration)
-const DUMMY_DAY_RECIPES: Array<{
-  name: string;
-  calories: number;
-  servingSize: string;
-  tags: string[];
-  nutrition: Nutrition;
-}> = [
-  {
-    name: "Chicken Tikka Masala",
-    calories: 225,
-    servingSize: "150g",
-    tags: ["Entree"],
-    nutrition: { calories: 225, protein: 22, fat: 9, carbs: 14, fiber: 2, sodium: 480 },
-  },
-  {
-    name: "Mango Fruit Cup",
-    calories: 100,
-    servingSize: "100g",
-    tags: ["Fruit"],
-    nutrition: { calories: 100, protein: 1, fat: 0, carbs: 25, fiber: 3, sodium: 10 },
-  },
-  {
-    name: "Steamed Broccoli",
-    calories: 55,
-    servingSize: "80g",
-    tags: ["Side"],
-    nutrition: { calories: 55, protein: 4, fat: 1, carbs: 10, fiber: 4, sodium: 30 },
   },
 ];
 
@@ -532,20 +500,7 @@ export default function MenuPlanning() {
               </>
             )}
 
-            {calendarView === "Day" && (
-              <div className="mt-4 flex flex-col gap-3">
-                {DUMMY_DAY_RECIPES.map((recipe) => (
-                  <RecipeDailyCard
-                    key={recipe.name}
-                    name={recipe.name}
-                    calories={recipe.calories}
-                    servingSize={recipe.servingSize}
-                    tags={recipe.tags}
-                  />
-                ))}
-                <DailyNutritionSummary recipes={DUMMY_DAY_RECIPES.map((r) => r.nutrition)} />
-              </div>
-            )}
+            {calendarView === "Day" && <DayView date={viewDates[0]} refetchTrigger={recipeDropTrigger} />}
           </div>
         </div>
 

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -423,7 +423,7 @@ export default function MenuPlanning() {
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <main className="flex flex-row">
         <div className="flex flex-1 justify-center items-center bg-gray-100">
-          <div className="flex flex-col h-full w-210">
+          <div className="flex flex-col h-full w-260">
             <div className="flex justify-between items-center mt-4">
               <div className="flex items-center justify-center gap-2">
                 <CurrentDateButton onClick={() => setDatesOffset(0)} />
@@ -504,7 +504,7 @@ export default function MenuPlanning() {
           </div>
         </div>
 
-        <div className="w-103.25">
+        <div className="w-90">
           <RecipeDatabase
             items={items}
             loading={loading}

--- a/src/components/WeeklyMenu.tsx
+++ b/src/components/WeeklyMenu.tsx
@@ -16,8 +16,8 @@ interface MealItem {
 const TAG_STYLES: Record<string, string> = {
   Combo: "bg-jicama text-radish-900",
   Sides: "bg-lime text-black",
-  Fruit: "bg-fruit-900 text-white",
-  Entree: "bg-entree-900 text-white",
+  Fruit: "bg-fruit-900 text-black",
+  Entree: "bg-entree-900 text-black",
 };
 
 // Mock meal data
@@ -149,7 +149,7 @@ export default function WeeklyMenu({ dateToday }: WeeklyMenuProps) {
           <p className="text-dark-gray text-sm text-center my-auto">No meals planned for this day.</p>
         ) : (
           meals.map((meal, idx) => {
-            const style = TAG_STYLES[meal.tag] ?? "bg-pepper text-white";
+            const style = TAG_STYLES[meal.tag] ?? "bg-pepper text-black";
             return (
               <div key={idx} className={`rounded-lg px-4 py-3 ${style}`}>
                 <p className="font-bold text-sm leading-tight">{meal.name}</p>

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -1,0 +1,175 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+import { Trash2 } from "lucide-react";
+import DroppableCalendarArea from "./DroppableCalendarArea";
+import DailyNutritionSummary from "./DailyNutritionSummary";
+import { Nutrition } from "@/lib/types";
+
+interface DayViewProps {
+  date: Date;
+  refetchTrigger?: number;
+}
+
+type DayMeal = {
+  id: string;
+  name: string;
+  servingSize?: string;
+  tag: "Entree" | "Sides" | "Fruit" | string;
+  category: "entrees" | "sides" | "fruits";
+};
+
+type CalendarRecipe = {
+  _id: string;
+  name: string;
+  serving?: number;
+};
+
+type CalendarDayResponse = {
+  _id: string;
+  entrees?: CalendarRecipe[];
+  fruits?: CalendarRecipe[];
+  sides?: CalendarRecipe[];
+};
+
+const TAG_BY_CATEGORY: Record<string, string> = {
+  entrees: "Entree",
+  sides: "Sides",
+  fruits: "Fruit",
+};
+
+const TAG_STYLES: Record<string, string> = {
+  Entree: "bg-entree-900 text-entree-500",
+  Sides: "bg-sides-500 text-sides-900",
+  Fruit: "bg-fruit-500 text-fruit-900",
+  fallback: "bg-gray-100 text-gray-700",
+};
+
+const formatDayId = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}${month}${day}`;
+};
+
+export default function DayView({ date, refetchTrigger }: DayViewProps) {
+  const [meals, setMeals] = useState<DayMeal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const dayId = formatDayId(date);
+
+  const fetchDayMeals = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/calendar/${dayId}`);
+
+      if (response.status === 404) {
+        setMeals([]);
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch calendar day ${dayId}`);
+      }
+
+      const calendarDay: CalendarDayResponse = await response.json();
+
+      const mapRecipes = (recipes: CalendarRecipe[] | undefined, category: "entrees" | "sides" | "fruits"): DayMeal[] =>
+        (recipes ?? []).map((recipe) => ({
+          id: recipe._id,
+          name: recipe.name,
+          servingSize: recipe.serving != null ? `${recipe.serving} servings` : undefined,
+          tag: TAG_BY_CATEGORY[category],
+          category,
+        }));
+
+      setMeals([
+        ...mapRecipes(calendarDay.entrees, "entrees"),
+        ...mapRecipes(calendarDay.sides, "sides"),
+        ...mapRecipes(calendarDay.fruits, "fruits"),
+      ]);
+    } catch (error) {
+      console.error("Error fetching day meals:", error);
+      setMeals([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dayId]);
+
+  useEffect(() => {
+    fetchDayMeals();
+  }, [fetchDayMeals, refetchTrigger]);
+
+  const handleDelete = async (meal: DayMeal) => {
+    setDeletingId(meal.id);
+    try {
+      const response = await fetch(`/api/calendar/${dayId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recipeId: meal.id, category: meal.category }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete recipe from calendar`);
+      }
+
+      setMeals((prev) => prev.filter((m) => !(m.id === meal.id && m.category === meal.category)));
+    } catch (error) {
+      console.error("Error deleting recipe from calendar:", error);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const emptyNutrition: Nutrition[] = [];
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      <DroppableCalendarArea dayId={dayId}>
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 py-8 text-center font-montserrat text-xs font-medium text-pepper/55">
+            Loading meals...
+          </div>
+        ) : meals.length > 0 ? (
+          meals.map((meal) => {
+            const tagStyle = TAG_STYLES[meal.tag] ?? TAG_STYLES.fallback;
+            return (
+              <div
+                key={`${meal.id}-${meal.category}`}
+                className="flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md"
+              >
+                <div className="flex-1 min-w-0">
+                  <h3 className="truncate text-xl font-bold font-montserrat" title={meal.name}>
+                    {meal.name}
+                  </h3>
+                  {meal.servingSize ? (
+                    <p className="text-base font-medium font-montserrat text-pepper/70">{meal.servingSize}</p>
+                  ) : null}
+                </div>
+
+                <span className={`shrink-0 rounded-md px-3 py-1.5 text-base font-medium font-montserrat ${tagStyle}`}>
+                  {meal.tag}
+                </span>
+
+                <button
+                  onClick={() => handleDelete(meal)}
+                  disabled={deletingId === meal.id}
+                  className="shrink-0 rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
+                  aria-label={`Remove ${meal.name}`}
+                >
+                  <Trash2 size={18} strokeWidth={1.7} />
+                </button>
+              </div>
+            );
+          })
+        ) : (
+          <div className="flex flex-1 items-center justify-center py-8 text-center font-montserrat text-sm font-medium text-pepper/55">
+            Drop a recipe here to add it to today&apos;s menu
+          </div>
+        )}
+      </DroppableCalendarArea>
+
+      <DailyNutritionSummary recipes={emptyNutrition} />
+    </div>
+  );
+}

--- a/src/components/menuPlanning/DroppableCalendarArea.tsx
+++ b/src/components/menuPlanning/DroppableCalendarArea.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from "react";
 interface DroppableCalendarAreaProps {
   dayId: string;
   children: ReactNode;
+  className?: string;
 }
 
 export default function DroppableCalendarArea({ dayId, children }: DroppableCalendarAreaProps) {
@@ -19,7 +20,7 @@ export default function DroppableCalendarArea({ dayId, children }: DroppableCale
   return (
     <div
       ref={setNodeRef}
-      className={`flex h-full min-h-[220px] w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
+      className={`flex h-full min-h-55 w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
         isOver ? "bg-radish-100 border-2 border-radish-900" : "border border-medium-gray/20 bg-white/30"
       }`}
     >

--- a/src/components/menuPlanning/RecipeDatabase.tsx
+++ b/src/components/menuPlanning/RecipeDatabase.tsx
@@ -70,7 +70,7 @@ export default function RecipeDatabase({
   onPageChange,
 }: RecipeDatabaseProps) {
   return (
-    <div className="p-6 h-[calc(100vh-140px)] overflow-y-auto">
+    <div className="p-6 h-full">
       <div className="text-xl font-semibold mb-6">Recipe Database</div>
 
       <div className="flex flex-row items-center gap-4">


### PR DESCRIPTION
## Developer: Derrick Phan

Closes #146 

### Pull Request Summary

Implemented drag and drop functionality for the daily calendar view. Users can drag recipes from the Recipe Database sidebar into the day view and it will save into the DB.

### Modifications

- components/menuPlanning/DayView.tsx: New component that fetches real calendar data for the day
- app/menuPlanning/page.tsx: Replaced dummy Day view data with the new DayView component                                                                                                              - src/components/menuPlanning/DroppableCalendarArea.tsx: Added a className prop

### Testing Considerations

I tested to make sure that you can drag onto the day view and that it saves into Mongo and same with when you delete something from the day view.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
