### PR TITLE
151 color code functionality changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.10.0.tgz",
-      "integrity": "sha512-1lI6HomyoO/8RSJb6ItyHLpHnB2z27m5F4aX/Vpi1nhwWoxdNjkq+6UQOykHyCE0KairojOE5qQ20i1tnF0nNA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.1.tgz",
+      "integrity": "sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -24,8 +24,6 @@ export default function DraftsPage() {
   const [showPublishModal, setShowPublishModal] = useState(false);
   const [busy, setBusy] = useState<"publish" | "delete" | null>(null);
 
-  // TODO: make recipes also selectable, currently only ComboCard has selection button
-  // figma doesn't have styles for selectable RecipeCard
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [selectedNames, setSelectedNames] = useState<Record<string, string>>({});
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
@@ -68,11 +66,6 @@ export default function DraftsPage() {
       return next;
     });
   };
-  /*
-    TODO: style DraftEntryCard (the card that links to the drafts page)
-    TODO: figure out what to do about selecting RecipeCards.
-    TODO: consider adding min-w and max-w to RecipeCard, allow for responsive grid. Combos are already responsive.
-  */
 
   const handleDelete = async () => {
     setShowDeleteModal(true);
@@ -156,9 +149,6 @@ export default function DraftsPage() {
         )}
       </div>
 
-      {/*TODO: Style buttons and whatnot */}
-      {/*TODO: separate into a component that takes the buttons as props. Permissions page also uses this */}
-      {/*TODO: refresh the page after a button click? or figure out a better way */}
       {selectedIds.size > 0 && (
         <div className="flex justify-between bg-white border-t border-gray-300 px-6 py-4 shadow-md">
           <div className="flex flex-wrap items-center gap-4">

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -66,12 +66,13 @@ const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
 ];
 
 type CalendarItem = {
-  _id?: string;
+  _id?: string; // TODO: why both id and _id? Half the code in this file is just for guessing which one to use.
   id?: string;
   name: string;
   serving?: number;
-  tags?: string[];
+  tags?: string[]; // TODO: too many things are optional, will silently fail on schema change
   itemType: "recipe" | "combo";
+  entrees?: string[];
   sides?: string[];
   fruits?: string[];
 };
@@ -81,9 +82,13 @@ type ActiveDragData = {
   recipeId?: string;
   name?: string;
   servingSize?: string;
-  tags?: string[];
-  primaryTag?: string;
   source?: string;
+  tags?: string[]; // TODO: too many things are optional, will silently fail on schema change
+  primaryTag?: string; // TODO: will turn into "category" on schema change
+  itemType?: "recipe" | "combo";
+  entrees?: string[];
+  sides?: string[];
+  fruits?: string[];
 };
 
 function TrashDropZone() {
@@ -324,6 +329,7 @@ export default function MenuPlanning() {
   useEffect(() => {
     async function fetchRecipesAndCombos() {
       try {
+        // TODO: why?
         const [recipesRes, combosRes] = await Promise.all([
           fetch("/api/recipes?isDraft=false&limit=200"),
           fetch("/api/combos?isDraft=false&limit=200"),
@@ -344,7 +350,8 @@ export default function MenuPlanning() {
         const comboItems: CalendarItem[] = (combosJson.data ?? []).map((combo: Combo) => ({
           ...combo,
           itemType: "combo",
-          tags: ["Combo", ...(combo.sides?.length ? ["Side"] : []), ...(combo.fruits?.length ? ["Fruit"] : [])],
+          tags: ["Combo"],
+          entrees: combo.entrees ?? [],
           sides: combo.sides ?? [],
           fruits: combo.fruits ?? [],
         }));
@@ -421,7 +428,7 @@ export default function MenuPlanning() {
       return;
     }
 
-    const { recipeId, tags, primaryTag, itemType, sides = [], fruits = [] } = dragData;
+    const { recipeId, tags, primaryTag, itemType, entrees = [], sides = [], fruits = [] } = dragData;
     const { dayId } = dropData;
 
     if (!recipeId || typeof recipeId !== "string" || recipeId.trim() === "") {
@@ -429,11 +436,12 @@ export default function MenuPlanning() {
       return;
     }
 
+    type CalendarCategory = "entrees" | "sides" | "fruits";
+
     const rawTags = Array.isArray(tags) ? tags : tags ? [tags] : [primaryTag || "Entree"];
     const normalizedTags = rawTags.map((tag) => tag?.toString().trim().toLowerCase()).filter(Boolean);
-    const hasComboTag = normalizedTags.includes("combo") || itemType === "combo";
 
-    const mapTagToCategory = (tag: string) => {
+    const mapTagToCategory = (tag: string): CalendarCategory | undefined => {
       switch (tag) {
         case "entree":
         case "entrée":
@@ -441,8 +449,6 @@ export default function MenuPlanning() {
           return "entrees";
         case "side":
         case "sides":
-        case "vegetarian":
-        case "soup":
           return "sides";
         case "fruit":
         case "fruits":
@@ -452,49 +458,38 @@ export default function MenuPlanning() {
       }
     };
 
-    const explicitCategories = Array.from(
-      new Set(
-        normalizedTags
-          .map(mapTagToCategory)
-          .filter((category): category is "entrees" | "sides" | "fruits" => Boolean(category)),
-      ),
-    );
+    const calendarItemsToAdd: Array<{ recipeId: string; category: CalendarCategory }> =
+      itemType === "combo"
+        ? [
+            ...entrees.map((id: string) => ({ recipeId: id, category: "entrees" as const })),
+            ...sides.map((id: string) => ({ recipeId: id, category: "sides" as const })),
+            ...fruits.map((id: string) => ({ recipeId: id, category: "fruits" as const })),
+          ].filter((item) => item.recipeId && item.recipeId.trim() !== "")
+        : [
+            {
+              recipeId,
+              category: normalizedTags.map(mapTagToCategory).find(Boolean) ?? "entrees",
+            },
+          ];
 
-    const defaultComboCategories: Array<"entrees" | "sides" | "fruits"> = [
-      ...(sides.length > 0 ? ["sides" as const] : []),
-      ...(fruits.length > 0 ? ["fruits" as const] : []),
-    ];
-
-    const categoriesToSend: Array<"entrees" | "sides" | "fruits"> =
-      explicitCategories.length > 0
-        ? explicitCategories
-        : hasComboTag
-          ? defaultComboCategories.length > 0
-            ? defaultComboCategories
-            : ["entrees"]
-          : ["entrees"];
-
-    const categoryItemIds = (category: "entrees" | "sides" | "fruits"): string[] => {
-      if (itemType === "combo") {
-        if (category === "sides") return sides;
-        if (category === "fruits") return fruits;
-        return [];
-      }
-      return [recipeId];
-    };
+    if (calendarItemsToAdd.length === 0) {
+      console.error("No valid recipes found in dragged item:", dragData);
+      return;
+    }
 
     try {
       const responses = await Promise.all(
-        categoriesToSend.flatMap((category) =>
-          categoryItemIds(category).map((itemId) =>
-            fetch(`/api/calendar/${dayId}`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({ recipeId: itemId, category }),
+        calendarItemsToAdd.map((item) =>
+          fetch(`/api/calendar/${dayId}`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              recipeId: item.recipeId,
+              category: item.category,
             }),
-          ),
+          }),
         ),
       );
 
@@ -517,6 +512,8 @@ export default function MenuPlanning() {
     setActiveDragData(null);
   }, []);
 
+  // TODO: fix scroll logic
+  // scrollbar fixed to top, RecipeDatabase to fill height, scrollable calendar area.
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
       <main className="flex flex-row">
@@ -584,7 +581,6 @@ export default function MenuPlanning() {
                 <div className="mt-auto flex justify-end pb-4">
                   <TrashDropZone />
                 </div>
-                <WarningQuotaMonthly />
               </div>
             )}
 

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -66,11 +66,11 @@ const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
 ];
 
 type CalendarItem = {
-  _id?: string; // TODO: why both id and _id? Half the code in this file is just for guessing which one to use.
+  _id?: string;
   id?: string;
   name: string;
   serving?: number;
-  tags?: string[]; // TODO: too many things are optional, will silently fail on schema change
+  tags?: string[];
   itemType: "recipe" | "combo";
   entrees?: string[];
   sides?: string[];
@@ -83,8 +83,8 @@ type ActiveDragData = {
   name?: string;
   servingSize?: string;
   source?: string;
-  tags?: string[]; // TODO: too many things are optional, will silently fail on schema change
-  primaryTag?: string; // TODO: will turn into "category" on schema change
+  tags?: string[];
+  primaryTag?: string;
   itemType?: "recipe" | "combo";
   entrees?: string[];
   sides?: string[];
@@ -329,7 +329,6 @@ export default function MenuPlanning() {
   useEffect(() => {
     async function fetchRecipesAndCombos() {
       try {
-        // TODO: why?
         const [recipesRes, combosRes] = await Promise.all([
           fetch("/api/recipes?isDraft=false&limit=200"),
           fetch("/api/combos?isDraft=false&limit=200"),
@@ -512,8 +511,6 @@ export default function MenuPlanning() {
     setActiveDragData(null);
   }, []);
 
-  // TODO: fix scroll logic
-  // scrollbar fixed to top, RecipeDatabase to fill height, scrollable calendar area.
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
       <main className="flex flex-row">

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -72,7 +72,6 @@ export default function CardGrid({
           item={recipe}
           name={recipe.name}
           imageUrl={recipe.imageUrl}
-          // TODO: Update RecipeCard with correct recipe schema
           servingSize={recipe.serving.toString()}
           tags={[...(recipe.filters ?? []), ...(recipe.allergens ?? [])]}
           isDraft={recipe.isDraft}

--- a/src/components/ComboCard.tsx
+++ b/src/components/ComboCard.tsx
@@ -62,7 +62,7 @@ export default function ComboCard({
 
   return (
     <div
-      onClick={onOpen} // TODO: cursor pointer only if onOpen is provided?
+      onClick={onOpen}
       className={`relative h-86.5 overflow-hidden rounded-[14px] cursor-pointer ${isSelected ? "border-3 border-radish-900" : isDraft ? "border-3 border-dashed border-gray-300" : "border-2 border-gray-300"} bg-white`}
     >
       <div className="relative h-28 w-full bg-medium-gray">

--- a/src/components/DraftEntryCard.tsx
+++ b/src/components/DraftEntryCard.tsx
@@ -15,13 +15,6 @@ export default function DraftEntryCard({ variant, numDrafts }: Props) {
     router.push("/drafts");
   };
 
-  /*
-    TODO: find a way to factor out the layout from ComboCard and RecipeCard
-    to avoid code duplication.
-    Maybe use the actual RecipeCard and ComboCard, but add some props for a "View Drafts" variant
-  */
-
-  // Combo-style
   if (variant === "Combo") {
     return (
       <div

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import SearchBarClient from "@/components/SearchbarClient";
 import CategoryToggle from "@/components/CategoryToggle";
 import CardGrid from "@/components/CardGrid";
@@ -58,6 +56,7 @@ export default function MealBrowser({
   onToggleSelect,
   onOpenItem,
 }: Props) {
+  // TODO: bring toggle out to a helper function. Used in a lot of places
   const toggleCategory = (category: CategoryValue) => {
     setSelectedCategories((prev) => {
       const next = new Set<CategoryValue>(prev);
@@ -90,20 +89,22 @@ export default function MealBrowser({
 
   return (
     <div className="flex flex-1 flex-col gap-3 md:gap-4">
-      <div className="flex flex-col md:flex-row gap-3 md:gap-5 items-start md:items-center">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-5">
         {topLeftChildren}
-        <div className="flex gap-3 w-full items-center">
+
+        <div className="flex w-full items-center gap-3">
           <div className="flex-1">
             <SearchBarClient placeholder="Search a recipe" onSearch={setSearch} />
           </div>
+
           <AddNewRecipeButton />
+
+          {topRightChildren}
         </div>
-        {topRightChildren}
       </div>
 
-      <div className="flex flex-col md:gap-3">
-        <div className="flex flex-row items-center gap-2 md:gap-3">
-          {filterButton && <div className="hidden md:block">{filterButton}</div>}
+      <div className="flex flex-col gap-2 md:gap-3">
+        <div className="flex items-center gap-2 md:gap-3">
           <div className="flex-1">
             <CategoryToggle
               options={categoryOptions}
@@ -111,6 +112,20 @@ export default function MealBrowser({
               onToggle={toggleCategory}
             />
           </div>
+
+          <div className="hidden md:block">
+            <PaginationDisplay
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={(page) => setCurrentPage(page)}
+              disabled={loading}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 md:hidden">
+          <div>{filterButton}</div>
+
           <PaginationDisplay
             currentPage={currentPage}
             totalPages={totalPages}
@@ -120,7 +135,7 @@ export default function MealBrowser({
         </div>
       </div>
 
-      <div className="w-full pb-5 overflow-auto">
+      <div className="w-full overflow-auto pb-5">
         <CardGrid
           loading={loading}
           error={error}

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -56,7 +56,6 @@ export default function MealBrowser({
   onToggleSelect,
   onOpenItem,
 }: Props) {
-  // TODO: bring toggle out to a helper function. Used in a lot of places
   const toggleCategory = (category: CategoryValue) => {
     setSelectedCategories((prev) => {
       const next = new Set<CategoryValue>(prev);

--- a/src/components/PaginationDisplay.tsx
+++ b/src/components/PaginationDisplay.tsx
@@ -48,17 +48,17 @@ export default function PaginationDisplay({ currentPage, totalPages, onPageChang
   const rightDisabled = disabled || currentPage >= safeTotalPages;
 
   return (
-    <div className="flex items-center gap-1 md:gap-2 text-dark-gray text-sm md:text-base">
+    <div className="flex items-center lg:gap-1 text-dark-gray text-sm lg:text-base">
       <button
         type="button"
         onClick={goToPrevious}
         disabled={leftDisabled}
-        className="h-8 md:h-10 w-8 md:w-10 flex items-center justify-center cursor-pointer enabled:hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
+        className="h-8 lg:h-10 w-8 lg:w-10 flex items-center justify-center cursor-pointer enabled:hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
       >
-        <div className="text-2xl md:text-3xl leading-none text-gray-500">{`\u2039`}</div>
+        <div className="text-2xl lg:text-3xl leading-none text-gray-500">{`\u2039`}</div>
       </button>
 
-      <div className="flex items-center gap-1 md:gap-2">
+      <div className="flex items-center gap-1">
         <input
           type="number"
           min={1}
@@ -72,9 +72,9 @@ export default function PaginationDisplay({ currentPage, totalPages, onPageChang
               commitInput();
             }
           }}
-          className="h-8 md:h-9 w-8 md:w-9 rounded-md border border-black-200 bg-white text-xs md:text-sm leading-none font-normal text-center text-black outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none disabled:opacity-60"
+          className="h-8 lg:h-9 w-8 lg:w-9 rounded-md border border-black-200 bg-white text-xs lg:text-sm leading-none font-normal text-center text-black outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none disabled:opacity-60"
         />
-        <div className="text-xs md:text-m font-normal leading-none text-black whitespace-nowrap">
+        <div className="text-xs lg:text-m font-normal leading-none text-black whitespace-nowrap">
           of {safeTotalPages}
         </div>
       </div>
@@ -83,9 +83,9 @@ export default function PaginationDisplay({ currentPage, totalPages, onPageChang
         type="button"
         onClick={goToNext}
         disabled={rightDisabled}
-        className="h-8 md:h-10 w-8 md:w-10 flex items-center justify-center cursor-pointer enabled:hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
+        className="h-8 lg:h-10 w-8 lg:w-10 flex items-center justify-center cursor-pointer enabled:hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
       >
-        <div className="text-2xl md:text-3xl leading-none text-gray-500">{`\u203A`}</div>
+        <div className="text-2xl lg:text-3xl leading-none text-gray-500">{`\u203A`}</div>
       </button>
     </div>
   );

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -3,6 +3,7 @@ import { Pencil } from "lucide-react";
 import { useState } from "react";
 import CreateRecipePopUp from "./CreateRecipePopUp";
 import { Recipe } from "@/lib/types";
+import { TAG_STYLES } from "@/lib/types";
 
 export type RecipeCardProps = {
   item: Recipe;
@@ -15,14 +16,6 @@ export type RecipeCardProps = {
   isSelected?: boolean;
   onSelect?: () => void;
   onOpen?: () => void;
-};
-const TAG_STYLES: Record<string, string> = {
-  Combo: "bg-combo-500 text-combo-900",
-  Side: "bg-sides-500 text-sides-900",
-  Fruit: "bg-fruit-500 text-fruit-900",
-  Entree: "bg-entree-900 text-entree-500",
-  Entrée: "bg-entree-900 text-entree-500",
-  fallback: "bg-gray-100 text-gray-700",
 };
 
 export default function RecipeCard({

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { useMealData } from "@/hooks/useMealData";
 import { Recipe, Combo } from "@/lib/types";
 import { CreateRecipeType } from "@/components/CreateRecipePopUp";
-import { Menu, Utensils } from "lucide-react";
+import { Menu, Utensils, SlidersHorizontal } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 
 function cloneFilterSelections(f: FilterSelections): FilterSelections {
@@ -83,15 +83,16 @@ export default function RecipePageClient() {
         selectedCategories={selectedCategories}
         setSelectedCategories={setSelectedCategories}
         onOpenItem={handleOpenItem}
-        topRightChildren={
+        filterButton={
           <button
             type="button"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-medium-gray bg-white text-pepper md:hidden"
+            className="flex items-center gap-2 rounded-md text-pepper md:hidden"
             aria-expanded={mobileFiltersOpen}
             aria-label="Open filters"
             onClick={() => setMobileFiltersOpen(true)}
           >
-            <Menu className="h-6 w-6" strokeWidth={2} aria-hidden />
+            <SlidersHorizontal className="h-6 w-6" strokeWidth={2} aria-hidden />
+            <span className="font-montserrat text-md font-semibold">Filters</span>
           </button>
         }
       />
@@ -99,7 +100,7 @@ export default function RecipePageClient() {
       <div className="hidden w-px shrink-0 bg-dark-gray md:block md:self-stretch" />
 
       {mobileFiltersOpen ? (
-        <div className="fixed inset-0 z-50 flex h-[100dvh] min-h-0 flex-col bg-white md:hidden">
+        <div className="fixed inset-0 z-50 flex h-dvh min-h-0 flex-col bg-white md:hidden">
           <FilterMenu
             mobileOverlay={{ onClose: () => setMobileFiltersOpen(false) }}
             initialSelections={filters}

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -324,7 +324,6 @@ export default function ViewRecipePopUp({ open, onClose, item, isComboMode, chan
             )}
 
             {/* ingredients (recipe) */}
-            {/* TODO: figma shows that combos also have ingredients, but the schema doesnt (maybe its just sides + fruit?) */}
             {"ingredients" in item && item.ingredients && (
               <>
                 <div className="hidden md:block h-px w-full bg-medium-gray my-8" />
@@ -343,7 +342,6 @@ export default function ViewRecipePopUp({ open, onClose, item, isComboMode, chan
             )}
 
             {/* instructions */}
-            {/* TODO: fix instructions schema (change from string -> array) */}
             {"instructions" in item && item.instructions && (
               <>
                 <div className="hidden md:block h-px w-full bg-medium-gray my-8" />

--- a/src/components/menuPlanning/DraggableRecipeCard.tsx
+++ b/src/components/menuPlanning/DraggableRecipeCard.tsx
@@ -11,6 +11,7 @@ interface DraggableRecipeCardProps {
   servingSize?: string;
   tags?: string[];
   itemType?: "recipe" | "combo";
+  entrees?: string[]; // TODO: Fragile to schema changes. Maybe just make each item keep it's own type.
   sides?: string[];
   fruits?: string[];
   disabled?: boolean;
@@ -33,6 +34,7 @@ export default function DraggableRecipeCard({
   servingSize,
   tags = [],
   itemType,
+  entrees = [],
   sides = [],
   fruits = [],
   disabled = false,
@@ -41,13 +43,16 @@ export default function DraggableRecipeCard({
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `recipe-${recipeId}`,
+    // TODO: create a type for this in types.ts shared between draggable items.
     data: {
       type: "recipe",
+      source: "sidebar",
       recipeId,
       name,
       tags: normalizedTags,
       primaryTag: normalizedTags[0] || "Entree",
       itemType,
+      entrees,
       sides,
       fruits,
     },
@@ -94,7 +99,7 @@ export default function DraggableRecipeCard({
         </span>
       ) : null}
 
-      <GripVertical size={20} strokeWidth={1.7} className="cursor-move text-gray-500 flex-shrink-0" />
+      <GripVertical size={20} strokeWidth={1.7} className="cursor-move text-gray-500 shrink-0" />
     </div>
   );
 }

--- a/src/components/menuPlanning/DraggableRecipeCard.tsx
+++ b/src/components/menuPlanning/DraggableRecipeCard.tsx
@@ -11,7 +11,7 @@ interface DraggableRecipeCardProps {
   servingSize?: string;
   tags?: string[];
   itemType?: "recipe" | "combo";
-  entrees?: string[]; // TODO: Fragile to schema changes. Maybe just make each item keep it's own type.
+  entrees?: string[];
   sides?: string[];
   fruits?: string[];
   disabled?: boolean;
@@ -43,7 +43,6 @@ export default function DraggableRecipeCard({
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `recipe-${recipeId}`,
-    // TODO: create a type for this in types.ts shared between draggable items.
     data: {
       type: "recipe",
       source: "sidebar",

--- a/src/components/menuPlanning/RecipeDatabase.tsx
+++ b/src/components/menuPlanning/RecipeDatabase.tsx
@@ -145,8 +145,8 @@ export default function RecipeDatabase({
               servingSize={displayItem.serving ? `${displayItem.serving}g` : "100g"}
               tags={displayItem.tags ?? displayItem.filters ?? []}
               itemType={itemType}
-              entrees={displayItem.entrees ?? []} // TODO: Find a better way to deal with this, maybe?
-              sides={displayItem.sides ?? []} // This is fragile to schema changes
+              entrees={displayItem.entrees ?? []}
+              sides={displayItem.sides ?? []}
               fruits={displayItem.fruits ?? []}
             />
           );

--- a/src/components/menuPlanning/RecipeDatabase.tsx
+++ b/src/components/menuPlanning/RecipeDatabase.tsx
@@ -126,17 +126,28 @@ export default function RecipeDatabase({
             filters?: string[];
             nutritional_info?: { calories?: number };
             serving?: number;
+            itemType?: "recipe" | "combo";
+            entrees?: string[];
+            sides?: string[];
+            fruits?: string[];
           };
+
+          const itemId = String(displayItem.id ?? displayItem._id ?? "");
+          const itemType = displayItem.itemType ?? (selectedCategories.has("Combo") ? "combo" : "recipe");
 
           return (
             <DraggableRecipeCard
-              recipeId={String(displayItem.id ?? displayItem._id ?? "")}
+              recipeId={itemId}
               key={displayItem.id ?? displayItem._id ?? index}
-              imageUrl={""}
+              imageUrl=""
               name={displayItem.name ?? "Untitled"}
               calories={displayItem.nutritional_info?.calories ?? 0}
               servingSize={displayItem.serving ? `${displayItem.serving}g` : "100g"}
               tags={displayItem.tags ?? displayItem.filters ?? []}
+              itemType={itemType}
+              entrees={displayItem.entrees ?? []} // TODO: Find a better way to deal with this, maybe?
+              sides={displayItem.sides ?? []} // This is fragile to schema changes
+              fruits={displayItem.fruits ?? []}
             />
           );
         })}

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -4,7 +4,6 @@ import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { TAG_STYLES } from "@/lib/types";
 
-// TODO: pull this out into the enum definition for the recipe schema
 export type CalendarMealCategory = "entrees" | "sides" | "fruits";
 
 export type WeekMealCardData = {
@@ -12,7 +11,7 @@ export type WeekMealCardData = {
   name: string;
   calories?: number;
   servingSize?: string;
-  tag?: "Entree" | "Entrée" | "Sides" | "Side" | "Fruit" | string; // TODO: once category is an enum this type can be replaced
+  tag?: "Entree" | "Entrée" | "Sides" | "Side" | "Fruit" | string;
   calendarDayId?: string;
   calendarCategory?: CalendarMealCategory;
 };

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -4,6 +4,7 @@ import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { TAG_STYLES } from "@/lib/types";
 
+// TODO: pull this out into the enum definition for the recipe schema
 export type CalendarMealCategory = "entrees" | "sides" | "fruits";
 
 export type WeekMealCardData = {
@@ -11,7 +12,7 @@ export type WeekMealCardData = {
   name: string;
   calories?: number;
   servingSize?: string;
-  tag?: "Entree" | "Entrée" | "Sides" | "Side" | "Fruit" | string;
+  tag?: "Entree" | "Entrée" | "Sides" | "Side" | "Fruit" | string; // TODO: once category is an enum this type can be replaced
   calendarDayId?: string;
   calendarCategory?: CalendarMealCategory;
 };

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -2,44 +2,21 @@
 
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
+import { TAG_STYLES } from "@/lib/types";
+
+export type CalendarMealCategory = "entrees" | "sides" | "fruits";
 
 export type WeekMealCardData = {
   id: string;
   name: string;
   calories?: number;
   servingSize?: string;
-  tag?: "Entree" | "Sides" | "Fruit" | "Combo" | string;
-  backgroundColor?: string;
-  textColor?: string;
+  tag?: "Entree" | "Entrée" | "Sides" | "Side" | "Fruit" | string;
   calendarDayId?: string;
-  calendarCategory?: "entrees" | "sides" | "fruits";
+  calendarCategory?: CalendarMealCategory;
 };
 
 type WeekMealCardProps = WeekMealCardData;
-
-const CARD_STYLE_BY_TAG: Record<string, { backgroundColor: string; textColor: string }> = {
-  Combo: {
-    backgroundColor: "var(--color-jicama)",
-    textColor: "var(--color-radish-900)",
-  },
-  Sides: {
-    backgroundColor: "var(--color-lime)",
-    textColor: "var(--color-pepper)",
-  },
-  Fruit: {
-    backgroundColor: "var(--color-fruit-900)",
-    textColor: "#ffffff",
-  },
-  Entree: {
-    backgroundColor: "var(--color-entree-500)",
-    textColor: "var(--color-pepper)",
-  },
-};
-
-const DEFAULT_CARD_STYLE = {
-  backgroundColor: "var(--color-pepper)",
-  textColor: "#ffffff",
-};
 
 export default function WeekMealCard({
   id,
@@ -47,13 +24,15 @@ export default function WeekMealCard({
   calories,
   servingSize,
   tag,
-  backgroundColor,
-  textColor,
   calendarDayId,
   calendarCategory,
 }: WeekMealCardProps) {
+  const dragId = `calendar-${calendarDayId ?? "unknown"}-${calendarCategory ?? "unknown"}-${id}`;
+  const tagClassName = tag ? (TAG_STYLES[tag] ?? TAG_STYLES.fallback) : TAG_STYLES.fallback;
+
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: `calendar-${calendarDayId}-${calendarCategory}-${id}`,
+    id: dragId,
+    disabled: !calendarDayId || !calendarCategory,
     data: {
       type: "recipe",
       source: "calendar",
@@ -66,19 +45,16 @@ export default function WeekMealCard({
       primaryTag: tag,
     },
   });
-  const tagStyle = tag ? (CARD_STYLE_BY_TAG[tag] ?? DEFAULT_CARD_STYLE) : DEFAULT_CARD_STYLE;
-  const resolvedBackgroundColor = backgroundColor ?? tagStyle.backgroundColor;
-  const resolvedTextColor = textColor ?? tagStyle.textColor;
+
   const caloriesText = calories != null ? `${calories} cal` : null;
   const metaText = caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || servingSize;
 
   return (
     <div
       ref={setNodeRef}
-      className={`flex cursor-move items-center gap-3 rounded-md px-4 py-3 font-montserrat shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${
+      className={`flex cursor-move items-center gap-3 rounded-md px-4 py-3 font-montserrat shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
         isDragging ? "opacity-40" : ""
       }`}
-      style={{ backgroundColor: resolvedBackgroundColor, color: resolvedTextColor }}
       {...attributes}
       {...listeners}
     >
@@ -86,6 +62,7 @@ export default function WeekMealCard({
         <p className="truncate text-[16px] leading-tight font-bold" title={name}>
           {name}
         </p>
+
         {metaText ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{metaText}</p> : null}
       </div>
 

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -1,6 +1,7 @@
 "use client";
+
 import { useEffect, useState } from "react";
-import WeekMealCard, { type WeekMealCardData } from "./WeekMealCard";
+import WeekMealCard, { type CalendarMealCategory, type WeekMealCardData } from "./WeekMealCard";
 import NutritionInfoNotMetCard from "./NutritionInfoNotMetCard";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 
@@ -19,6 +20,9 @@ type CalendarRecipe = {
   _id: string;
   name: string;
   serving?: number;
+  nutritional_info?: {
+    calories?: number;
+  };
 };
 
 type CalendarDayResponse = {
@@ -28,74 +32,107 @@ type CalendarDayResponse = {
   sides?: CalendarRecipe[];
 };
 
-const formatCalendarDayId = (date: Date) => {
+const CALENDAR_SECTIONS: Array<{
+  category: CalendarMealCategory;
+  tag: WeekMealCardData["tag"];
+}> = [
+  { category: "entrees", tag: "Entree" },
+  { category: "sides", tag: "Sides" },
+  { category: "fruits", tag: "Fruit" },
+];
+
+const EMPTY_DAY: WeekViewDayData = {
+  meals: [],
+  showNutritionInfoNotMet: false,
+};
+
+function formatCalendarDayId(date: Date) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
-  return `${year}${month}${day}`;
-};
 
-const mapCalendarRecipesToMeals = (
+  return `${year}${month}${day}`;
+}
+
+function mapCalendarRecipesToMeals(
   recipes: CalendarRecipe[] | undefined,
   tag: WeekMealCardData["tag"],
-  calendarCategory: WeekMealCardData["calendarCategory"],
+  calendarCategory: CalendarMealCategory,
   calendarDayId: string,
-) =>
-  (recipes ?? []).map((recipe) => ({
+): WeekMealCardData[] {
+  return (recipes ?? []).map((recipe) => ({
     id: recipe._id,
     name: recipe.name,
-    servingSize: recipe.serving != null ? `${recipe.serving} servings` : undefined,
+    calories: recipe.nutritional_info?.calories,
+    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined, // TODO: unclear if this should be in grams or not
     tag,
     calendarCategory,
     calendarDayId,
   }));
+}
+
+function mapCalendarDayToMeals(calendarDay: CalendarDayResponse, fallbackDayId: string): WeekMealCardData[] {
+  const calendarDayId = calendarDay._id || fallbackDayId;
+
+  return CALENDAR_SECTIONS.flatMap(({ category, tag }) =>
+    mapCalendarRecipesToMeals(calendarDay[category], tag, category, calendarDayId),
+  );
+}
+
+async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promise<WeekViewDayData> {
+  const response = await fetch(`/api/calendar/${dayId}`, { signal });
+
+  if (response.status === 404) {
+    return {
+      meals: [],
+      showNutritionInfoNotMet: true,
+    };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch calendar day ${dayId}`);
+  }
+
+  const calendarDay: CalendarDayResponse = await response.json();
+
+  return {
+    meals: mapCalendarDayToMeals(calendarDay, dayId),
+    showNutritionInfoNotMet: false,
+  };
+}
 
 export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekViewProps) {
   const [weekViewMeals, setWeekViewMeals] = useState<WeekViewDayData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  const weekDayIds = weekDates.map(formatCalendarDayId);
+  const weekKey = weekDayIds.join("|");
+
   useEffect(() => {
-    let isMounted = true;
+    const controller = new AbortController();
+    const dayIds = weekKey ? weekKey.split("|") : [];
 
     async function fetchWeekMeals() {
       setIsLoading(true);
 
       try {
-        const weekMeals = await Promise.all(
-          weekDates.map(async (date) => {
-            const response = await fetch(`/api/calendar/${formatCalendarDayId(date)}`);
+        const mealsByDay = await Promise.all(dayIds.map((dayId) => fetchCalendarDayMeals(dayId, controller.signal)));
 
-            if (response.status === 404) {
-              return { meals: [], showNutritionInfoNotMet: true };
-            }
-
-            if (!response.ok) {
-              throw new Error(`Failed to fetch calendar day ${formatCalendarDayId(date)}`);
-            }
-
-            const calendarDay: CalendarDayResponse = await response.json();
-
-            return {
-              meals: [
-                ...mapCalendarRecipesToMeals(calendarDay.entrees, "Entree", "entrees", calendarDay._id),
-                ...mapCalendarRecipesToMeals(calendarDay.sides, "Sides", "sides", calendarDay._id),
-                ...mapCalendarRecipesToMeals(calendarDay.fruits, "Fruit", "fruits", calendarDay._id),
-              ],
-              showNutritionInfoNotMet: false,
-            };
-          }),
-        );
-
-        if (isMounted) {
-          setWeekViewMeals(weekMeals);
+        if (!controller.signal.aborted) {
+          setWeekViewMeals(mealsByDay);
         }
       } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+
         console.error("Error fetching week meals:", error);
-        if (isMounted) {
-          setWeekViewMeals(weekDates.map(() => ({ meals: [], showNutritionInfoNotMet: false })));
+
+        if (!controller.signal.aborted) {
+          setWeekViewMeals(dayIds.map(() => ({ ...EMPTY_DAY })));
         }
       } finally {
-        if (isMounted) {
+        if (!controller.signal.aborted) {
           setIsLoading(false);
         }
       }
@@ -103,52 +140,52 @@ export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekV
 
     fetchWeekMeals();
 
-    return () => {
-      isMounted = false;
-    };
-  }, [weekDates, refetchTrigger]);
+    return () => controller.abort();
+  }, [weekKey, refetchTrigger]);
 
   return (
     <div className="relative my-4 grid flex-1 grid-cols-5 gap-3">
-      {weekDates.map((date, idx) => (
-        <div key={idx} className="flex min-w-0 flex-col items-center">
-          <span className="text-xs font-montserrat font-medium tracking-[0.12em] text-pepper">
-            {date.toLocaleDateString(undefined, { weekday: "short" }).toUpperCase()}
-          </span>
-          <span
-            className={`mb-2 text-2xl font-montserrat font-bold ${
-              date.toDateString() === dateToday.toDateString() ? "text-radish-900" : "text-pepper"
-            }`}
-          >
-            {String(date.getDate()).padStart(2, "0")}
-          </span>
-          <div
-            className={`flex min-h-[420px] w-full flex-1 flex-col gap-3 rounded-[14px] p-3 ${
-              date.toDateString() === dateToday.toDateString()
-                ? "border-2 border-radish-900"
-                : "border border-medium-gray/35"
-            } bg-white`}
-          >
-            {isLoading ? (
-              <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 text-center font-montserrat text-xs font-medium text-pepper/55">
-                Loading meals...
-              </div>
-            ) : (weekViewMeals[idx]?.meals ?? []).length > 0 ? (
-              <DroppableCalendarArea dayId={formatCalendarDayId(date)}>
-                {weekViewMeals[idx]?.meals?.map((meal) => <WeekMealCard key={meal.id} {...meal} />) || null}
-              </DroppableCalendarArea>
-            ) : (
-              <DroppableCalendarArea dayId={formatCalendarDayId(date)}>
-                <div className="flex flex-1 items-center justify-center text-center font-montserrat text-xs font-medium text-pepper/55">
-                  Drop recipe here
-                </div>
-              </DroppableCalendarArea>
-            )}
+      {weekDates.map((date, index) => {
+        const dayId = weekDayIds[index] ?? formatCalendarDayId(date);
+        const dayData = weekViewMeals[index] ?? EMPTY_DAY;
+        const isToday = date.toDateString() === dateToday.toDateString();
 
-            {weekViewMeals[idx]?.showNutritionInfoNotMet ? <NutritionInfoNotMetCard /> : null}
+        return (
+          <div key={dayId} className="flex min-w-0 flex-col items-center">
+            <span className="text-xs font-montserrat font-medium tracking-[0.12em] text-pepper">
+              {date.toLocaleDateString(undefined, { weekday: "short" }).toUpperCase()}
+            </span>
+
+            <span className={`mb-2 text-2xl font-montserrat font-bold ${isToday ? "text-radish-900" : "text-pepper"}`}>
+              {String(date.getDate()).padStart(2, "0")}
+            </span>
+
+            <div
+              className={`flex min-h-105 w-full flex-1 flex-col gap-3 rounded-[14px] p-3 ${
+                isToday ? "border-2 border-radish-900" : "border border-medium-gray/35"
+              } bg-white`}
+            >
+              <DroppableCalendarArea dayId={dayId}>
+                {isLoading ? (
+                  <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 text-center font-montserrat text-xs font-medium text-pepper/55">
+                    Loading meals...
+                  </div>
+                ) : dayData.meals.length > 0 ? (
+                  dayData.meals.map((meal) => (
+                    <WeekMealCard key={`${meal.calendarDayId}-${meal.calendarCategory}-${meal.id}`} {...meal} />
+                  ))
+                ) : (
+                  <div className="flex flex-1 items-center justify-center text-center font-montserrat text-xs font-medium text-pepper/55">
+                    Drop recipe here
+                  </div>
+                )}
+              </DroppableCalendarArea>
+
+              {!isLoading && dayData.showNutritionInfoNotMet ? <NutritionInfoNotMetCard /> : null}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -64,7 +64,7 @@ function mapCalendarRecipesToMeals(
     id: recipe._id,
     name: recipe.name,
     calories: recipe.nutritional_info?.calories,
-    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined, // TODO: unclear if this should be in grams or something
+    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined,
     tag,
     calendarCategory,
     calendarDayId,
@@ -79,7 +79,6 @@ function mapCalendarDayToMeals(calendarDay: CalendarDayResponse, fallbackDayId: 
   );
 }
 
-// TODO: Fix the calendar API. Fetching every day individually is painful.
 async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promise<WeekViewDayData> {
   const response = await fetch(`/api/calendar/${dayId}`, { signal });
 

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -64,7 +64,7 @@ function mapCalendarRecipesToMeals(
     id: recipe._id,
     name: recipe.name,
     calories: recipe.nutritional_info?.calories,
-    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined, // TODO: unclear if this should be in grams or not
+    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined, // TODO: unclear if this should be in grams or something
     tag,
     calendarCategory,
     calendarDayId,
@@ -79,6 +79,7 @@ function mapCalendarDayToMeals(calendarDay: CalendarDayResponse, fallbackDayId: 
   );
 }
 
+// TODO: Fix the calendar API. Fetching every day individually is painful.
 async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promise<WeekViewDayData> {
   const response = await fetch(`/api/calendar/${dayId}`, { signal });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,3 +59,14 @@ export const EMPTY_FILTERS: FilterSelections = {
 export type SortOption = "lastUpdated" | "createdDate" | "aToZ" | "zToA";
 export type CategoryValue = "Entree" | "Side" | "Fruit" | "Combo";
 export type FilterSelections = Record<string, Set<string>>;
+
+// TODO: When the recipe schema is finalized, update this to use item.category
+// instead of tags/filters. Expected future categories: ENTREE, FRUIT, VEGETABLE, GRAIN.
+export const TAG_STYLES: Record<string, string> = {
+  Combo: "bg-combo-500 text-combo-900",
+  Side: "bg-sides-500 text-sides-900",
+  Fruit: "bg-fruit-500 text-fruit-900",
+  Entree: "bg-entree-900 text-entree-500",
+  Entrée: "bg-entree-900 text-entree-500",
+  fallback: "bg-gray-100 text-gray-700",
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,8 +60,6 @@ export type SortOption = "lastUpdated" | "createdDate" | "aToZ" | "zToA";
 export type CategoryValue = "Entree" | "Side" | "Fruit" | "Combo";
 export type FilterSelections = Record<string, Set<string>>;
 
-// TODO: When the recipe schema is finalized, update this to use item.category
-// instead of tags/filters. Expected future categories: ENTREE, FRUIT, VEGETABLE, GRAIN.
 export const TAG_STYLES: Record<string, string> = {
   Combo: "bg-combo-500 text-combo-900",
   Side: "bg-sides-500 text-sides-900",


### PR DESCRIPTION
## Developer: Kevin Diaz

Closes #151 

### Pull Request Summary

Color coding of menu planning cards, combo separation, recipe page filter button.

I made only functionality changes, I did not attempt to make it forward compatible with the new schema yet (new categories, new place to find the category) because I think that will make the code unreadable and then no one will want to go back and clean it up after. 

The color definitions are moved to types.ts (and globals.css), so once schema changes it should be easy to add the new colors.

### Modifications

- `WeekMealCard.tsx`: updated meal card coloring to use class names instead of inline styles so Tailwind styles apply correctly.
- `WeekView.tsx`: cleaned up week meal fetching, added abort handling, and kept meal cards mapped by entree, side, and fruit.
- `MenuPlanning/page.tsx`: updated combo drop behavior so combos are added to the calendar as their separate recipes instead of one combo card.
- `RecipeDatabase.tsx`: passed combo recipe data through to draggable cards so combo drops have the needed entree, side, and fruit data.
- `DraggableRecipeCard.tsx`: added combo data to drag payload.
- `MealBrowser.tsx`: moved the mobile filter button and pagination below the category buttons.
- `RecipePageClient.tsx`: passed the mobile filter button through the correct `filterButton` slot instead of `topRightChildren`.
- `types.ts`: moved/shared tag style values used for meal card color coding.

### Testing Considerations

- Verified menu planning cards show the correct colors for entree, side, and fruit cards.
- Verified week view still loads calendar meals correctly.
- Verified dragging a normal recipe into the calendar still adds one recipe.
- Verified dragging a combo into the calendar adds the combo’s separate recipes instead of showing a combo card.
- Verified mobile recipe page layout shows category buttons first, then filters and pagination below.
- Verified desktop recipe page still shows pagination next to the category buttons.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="491" height="271" alt="image" src="https://github.com/user-attachments/assets/3c18919c-c87e-4ff5-b78d-54ad4a3f5396" />

<img width="721" height="472" alt="image" src="https://github.com/user-attachments/assets/e15bb546-60f6-4d55-9874-680e12e9cc6a" />

<img width="528" height="516" alt="image" src="https://github.com/user-attachments/assets/93fa54ec-bd5d-40d9-afb7-afbac08f0cf0" />
