### PR TITLE
feat: new filter schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
-  }
+  },
+  "files.eol": "\n"
 }

--- a/src/app/api/calendar/[id]/route.ts
+++ b/src/app/api/calendar/[id]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
+import "@/database/RecipeSchema";
 import Calendar from "@/database/CalendarSchema";
-import Recipe from "@/database/RecipeSchema";
 import { RECIPE_BUCKETS } from "@/lib/types";
-import type { RecipeBucket, RecipeBuckets } from "@/lib/types";
+import type { Recipe, RecipeBucket, RecipeBuckets } from "@/lib/types";
 
 type Params = {
   params: Promise<{
@@ -38,6 +38,8 @@ function getBucketIds(calendarDay: { get: (path: string) => unknown }, bucket: R
 }
 
 export async function GET(_req: NextRequest, { params }: Params) {
+  // Returns the fully populated calendar day.
+  // Buckets contain the entire recipe data, not just strings or preview.
   const { id } = await params;
 
   if (!id) {
@@ -47,52 +49,13 @@ export async function GET(_req: NextRequest, { params }: Params) {
   try {
     await connectDB();
 
-    const calendarDay = await Calendar.findById(id).exec();
+    const calendarDay = await Calendar.findById(id).populate(populateBucketPaths).lean().exec();
 
     if (!calendarDay) {
       return NextResponse.json({ error: "Calendar day not found" }, { status: 404 });
     }
 
-    const allIds = Array.from(new Set(RECIPE_BUCKETS.flatMap((bucket) => getBucketIds(calendarDay, bucket))));
-
-    const recipeDocs = await Recipe.find({ _id: { $in: allIds } })
-      .lean()
-      .exec();
-
-    const recipeLookup = new Map<string, CalendarRecipePreview>();
-
-    recipeDocs.forEach((doc) => {
-      if (doc._id) {
-        recipeLookup.set(doc._id.toString(), {
-          _id: doc._id.toString(),
-          name: doc.name,
-          serving: doc.serving,
-        });
-      }
-    });
-
-    const resolveRecipes = (ids: string[]) =>
-      ids.map((id) => recipeLookup.get(id) ?? { _id: id, name: id, serving: undefined });
-
-    const buckets = RECIPE_BUCKETS.reduce<RecipeBuckets<CalendarRecipePreview>>(
-      (acc, bucket) => {
-        acc[bucket] = resolveRecipes(getBucketIds(calendarDay, bucket));
-        return acc;
-      },
-      {
-        entrees: [],
-        vegetables: [],
-        fruits: [],
-        grains: [],
-      },
-    );
-
-    const response: CalendarDayResponse = {
-      _id: calendarDay._id.toString(),
-      ...buckets,
-    };
-
-    return NextResponse.json(response, { status: 200 });
+    return NextResponse.json(calendarDay, { status: 200 });
   } catch (err) {
     console.error("Error fetching calendar day:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
@@ -140,13 +103,13 @@ export async function DELETE(req: NextRequest, { params }: Params) {
 
   try {
     const body = await req.json();
-    const { recipeId, category } = body;
+    const { recipeId, category: bucket } = body;
 
-    if (!recipeId || !category) {
+    if (!recipeId || !bucket) {
       return NextResponse.json({ error: "recipeId and category are required" }, { status: 400 });
     }
 
-    if (!isRecipeBucket(category)) {
+    if (!isRecipeBucket(bucket)) {
       return NextResponse.json({ error: "Invalid category" }, { status: 400 });
     }
 
@@ -158,10 +121,10 @@ export async function DELETE(req: NextRequest, { params }: Params) {
       return NextResponse.json({ error: "Calendar day not found" }, { status: 404 });
     }
 
-    const currentIds = getBucketIds(calendarDay, category);
+    const currentIds = getBucketIds(calendarDay, bucket);
 
     calendarDay.set(
-      category,
+      bucket,
       currentIds.filter((itemId) => itemId !== recipeId),
     );
 

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Calendar from "@/database/CalendarSchema";
+import { RECIPE_BUCKETS } from "@/lib/types";
 
 export async function GET(req: NextRequest) {
   try {
@@ -9,21 +10,42 @@ export async function GET(req: NextRequest) {
     const searchParams = req.nextUrl.searchParams;
     const year = searchParams.get("year");
     const month = searchParams.get("month")?.padStart(2, "0");
+    const populate = searchParams.get("populate");
 
-    if (year && month) {
-      const yearMonth = `${year}${month}`;
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
 
-      const result = await Calendar.find({ _id: { $regex: `^${yearMonth}` } })
-        .populate("entrees")
-        .populate("vegetables")
-        .populate("fruits")
-        .populate("grains")
-        .exec();
+    const baseFilter =
+      year && month
+        ? {
+            _id: { $regex: `^${year}${month}` },
+          }
+        : {};
 
-      return NextResponse.json(result);
+    const query = Calendar.find(baseFilter);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    } else if (populate) {
+      return NextResponse.json(
+        {
+          error: "Invalid populate value. Use all, preview, nutrition, or filters.",
+        },
+        { status: 400 },
+      );
     }
 
-    const result = await Calendar.find().exec();
+    const result = await query.exec();
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error fetching calendar data:", error);

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
+import { RecipeBuckets } from "@/lib/types";
+import { deriveComboDataFromRecipeIds, getFinalRecipeBuckets } from "@/lib/server/comboHelpers";
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -35,7 +37,8 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: "Combo ID is required" }, { status: 400 });
   }
 
-  let updates = {};
+  let updates: Record<string, unknown>;
+
   try {
     updates = await req.json();
   } catch {
@@ -44,9 +47,31 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
   try {
     await connectDB();
+
+    const existingCombo = await Combo.findById(id)
+      .select("entrees vegetables fruits grains")
+      .lean<RecipeBuckets<string>>();
+
+    if (!existingCombo) {
+      return NextResponse.json({ error: "Combo not found" }, { status: 404 });
+    }
+
+    // get all recipes in this combo, including updates
+    const finalRecipeBuckets = getFinalRecipeBuckets(updates, existingCombo);
+    // aggregate the filters
+    const calculatedFilters = await deriveComboDataFromRecipeIds(finalRecipeBuckets);
+
     const updatedCombo = await Combo.findByIdAndUpdate(
       id,
-      { $set: updates },
+      {
+        $set: {
+          ...updates,
+
+          // The client cannot set the filters directly
+          // here we overwrite any client data with our own calculations
+          ...calculatedFilters,
+        },
+      },
       {
         new: true,
         runValidators: true,
@@ -63,6 +88,11 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (err?.name === "ValidationError" || err?.name === "StrictModeError") {
       return NextResponse.json({ error: "Invalid Data" }, { status: 400 });
     }
+
+    if (err?.message?.includes("Invalid") || err?.message?.includes("could not be found")) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
     console.error("Error updating combo:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
-import { RecipeBuckets } from "@/lib/types";
+import { RECIPE_BUCKETS, RecipeBuckets } from "@/lib/types";
 import { deriveComboDataFromRecipeIds, getFinalRecipeBuckets } from "@/lib/server/comboHelpers";
 
 type Params = {
@@ -17,7 +17,37 @@ export async function GET(req: NextRequest, { params }: Params) {
 
   try {
     await connectDB();
-    const combo = await Combo.findById(id);
+
+    const searchParams = req.nextUrl.searchParams;
+    const populate = searchParams.get("populate");
+
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
+
+    const query = Combo.findById(id);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    } else if (populate) {
+      return NextResponse.json(
+        {
+          error: "Invalid populate value. Use all, preview, nutrition, or filters.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const combo = await query.exec();
 
     if (!combo) {
       return NextResponse.json({ error: "Combo not found" }, { status: 404 });

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
 import { getNormalizedParams } from "@/lib/server/searchParams";
-import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES } from "@/lib/types";
+import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES, RECIPE_BUCKETS } from "@/lib/types";
 import { deriveComboDataFromRecipeIds, getRecipeBucketsFromBody } from "@/lib/server/comboHelpers";
 
 type ServingRange = {
@@ -33,12 +33,20 @@ export async function GET(req: NextRequest) {
 
     const isDraftParam = searchParams.get("isDraft");
     const sortBy = searchParams.get("sortBy") ?? "createdDate";
+    const populate = searchParams.get("populate");
 
     const proteinSourceParams = getNormalizedParams(searchParams, "proteinSources", PROTEIN_SOURCES);
 
     const dietaryParams = getNormalizedParams(searchParams, "dietary", DIETARY_KEYS);
 
     const exclusionParams = getNormalizedParams(searchParams, "exclusions", EXCLUSION_KEYS);
+
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
 
     const servingParams = searchParams
       .getAll("servings")
@@ -124,6 +132,16 @@ export async function GET(req: NextRequest) {
       .sort(sort)
       .skip((page - 1) * limit)
       .limit(limit);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    }
 
     if (sortBy === "aToZ" || sortBy === "zToA") {
       query = query.collation({ locale: "en", strength: 2 });

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -10,7 +10,6 @@ type ServingRange = {
   max?: number;
 };
 
-// TODO: overhaul this entire endpoint? not as serious as the recipe one
 const SERVING_FILTER_RANGES: Record<string, ServingRange> = {
   "single-serving": { min: 1, max: 1 },
   "small-serving": { min: 2, max: 3 },

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
+import { getNormalizedParams } from "@/lib/server/searchParams";
+import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES } from "@/lib/types";
+import { deriveComboDataFromRecipeIds, getRecipeBucketsFromBody } from "@/lib/server/comboHelpers";
 
 type ServingRange = {
   min: number;
@@ -22,15 +25,21 @@ export async function GET(req: NextRequest) {
     const searchParams = req.nextUrl.searchParams;
 
     const name = searchParams.get("name")?.trim();
-    const page = Number(searchParams.get("page") ?? 1);
-    const limit = Number(searchParams.get("limit") ?? 10);
+
+    const pageParam = Number(searchParams.get("page") ?? 1);
+    const limitParam = Number(searchParams.get("limit") ?? 10);
+
+    const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+    const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 10;
+
     const isDraftParam = searchParams.get("isDraft");
     const sortBy = searchParams.get("sortBy") ?? "createdDate";
 
-    const tagParams = searchParams
-      .getAll("filters")
-      .map((t) => t.trim().toLowerCase())
-      .filter(Boolean);
+    const proteinSourceParams = getNormalizedParams(searchParams, "proteinSources", PROTEIN_SOURCES);
+
+    const dietaryParams = getNormalizedParams(searchParams, "dietary", DIETARY_KEYS);
+
+    const exclusionParams = getNormalizedParams(searchParams, "exclusions", EXCLUSION_KEYS);
 
     const servingParams = searchParams
       .getAll("servings")
@@ -43,10 +52,30 @@ export async function GET(req: NextRequest) {
       filter.name = { $regex: name, $options: "i" };
     }
 
-    if (tagParams.length > 0) {
-      filter.filters = {
-        $all: tagParams.map((tag) => new RegExp(`^${tag}$`, "i")),
-      };
+    const andClauses: any[] = [];
+
+    if (proteinSourceParams.length > 0) {
+      // proteinSources=Chicken&proteinSources=Tofu
+      // means Chicken OR Tofu
+      andClauses.push({
+        proteinSources: { $in: proteinSourceParams },
+      });
+    }
+
+    // These are AND filters.
+    // dietary=halal&dietary=vegetarian means halal AND vegetarian.
+    for (const dietaryKey of dietaryParams) {
+      andClauses.push({
+        [`dietary.${dietaryKey}`]: true,
+      });
+    }
+
+    // exclusions=glutenFree&exclusions=nutFree
+    // means glutenFree AND nutFree.
+    for (const exclusionKey of exclusionParams) {
+      andClauses.push({
+        [`exclusions.${exclusionKey}`]: true,
+      });
     }
 
     const servingRanges = servingParams
@@ -54,9 +83,17 @@ export async function GET(req: NextRequest) {
       .filter((range): range is ServingRange => Boolean(range));
 
     if (servingRanges.length > 0) {
-      filter.$or = servingRanges.map((range) =>
-        range.max != null ? { serving: { $gte: range.min, $lte: range.max } } : { serving: { $gte: range.min } },
-      );
+      andClauses.push({
+        $or: servingRanges.map((range) =>
+          range.max != null ? { serving: { $gte: range.min, $lte: range.max } } : { serving: { $gte: range.min } },
+        ),
+      });
+    }
+
+    if (andClauses.length > 1) {
+      filter.$and = andClauses;
+    } else if (andClauses.length === 1) {
+      Object.assign(filter, andClauses[0]);
     }
 
     if (isDraftParam === "true") {
@@ -112,18 +149,40 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  let comboData: Record<string, unknown>;
+
   try {
-    const comboData = await req.json();
+    comboData = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
     await connectDB();
-    console.log(comboData, "COMBO DATA!");
-    const combo = new Combo(comboData);
+
+    const recipeBuckets = getRecipeBucketsFromBody(comboData);
+    const calculatedFilters = await deriveComboDataFromRecipeIds(recipeBuckets);
+
+    const combo = new Combo({
+      ...comboData,
+
+      // Filters are always derived in the backend.
+      // Here we overwrite anything the frontend may have sent.
+      ...calculatedFilters,
+    });
+
     await combo.save();
 
     return NextResponse.json(combo, { status: 201 });
   } catch (err: any) {
     if (err?.name === "ValidationError") {
-      return NextResponse.json({ error: "invalid data" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid data" }, { status: 400 });
     }
+
+    if (err?.message?.includes("Invalid") || err?.message?.includes("could not be found")) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
     console.error("Error creating combo:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -3,6 +3,7 @@ import connectDB, { getRecipeById } from "@/database/db";
 import Recipe from "@/database/RecipeSchema";
 import { RECIPE_CATEGORIES } from "@/lib/types";
 import type { RecipeCategory } from "@/lib/types";
+import { refreshCombosContainingRecipe, updateAffectsComboData } from "@/lib/server/comboHelpers";
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -67,6 +68,12 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     if (!updatedRecipe) {
       return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+    }
+
+    if (updateAffectsComboData(updates)) {
+      // Refresh combos only if this change would actually affect them.
+      // For example, a nutrition change or a filter change.
+      await refreshCombosContainingRecipe(id);
     }
 
     return NextResponse.json(updatedRecipe, { status: 200 });

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,7 +1,7 @@
 import connectDB, { postRecipe } from "@/database/db";
 import Recipe from "@/database/RecipeSchema";
-import { RECIPE_CATEGORIES } from "@/lib/types";
-import type { RecipeCategory } from "@/lib/types";
+import { getNormalizedParams } from "@/lib/server/searchParams";
+import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES, RECIPE_CATEGORIES } from "@/lib/types";
 import { NextRequest, NextResponse } from "next/server";
 
 type ServingRange = {
@@ -16,13 +16,6 @@ const SERVING_FILTER_RANGES: Record<string, ServingRange> = {
   "party-serving": { min: 7 },
 };
 
-function normalizeRecipeCategory(value: string): RecipeCategory | null {
-  // accepts capitalization differences.
-  // e.g, " entree " will normalize to "Entree" for searching
-  return RECIPE_CATEGORIES.find((category) => category.toLowerCase() === value.toLowerCase()) ?? null;
-}
-
-// TODO: For now just update categories, overhaul when updating the filters
 export async function GET(req: NextRequest) {
   try {
     await connectDB();
@@ -36,15 +29,14 @@ export async function GET(req: NextRequest) {
     const isSubrecipeParam = searchParams.get("isSubrecipe");
     const sortBy = searchParams.get("sortBy") ?? "createdDate";
 
-    const tagParams = searchParams
-      .getAll("filters")
-      .map((t) => t.trim().toLowerCase())
-      .filter(Boolean);
+    // Values that are not recognized will be thrown away.
+    const categoryParams = getNormalizedParams(searchParams, "categories", RECIPE_CATEGORIES);
 
-    const categoryParams = searchParams
-      .getAll("categories")
-      .map((category) => normalizeRecipeCategory(category.trim()))
-      .filter((category): category is RecipeCategory => Boolean(category));
+    const proteinSourceParams = getNormalizedParams(searchParams, "proteinSources", PROTEIN_SOURCES);
+
+    const dietaryParams = getNormalizedParams(searchParams, "dietary", DIETARY_KEYS);
+
+    const exclusionParams = getNormalizedParams(searchParams, "exclusions", EXCLUSION_KEYS);
 
     const servingParams = searchParams
       .getAll("servings")
@@ -59,14 +51,27 @@ export async function GET(req: NextRequest) {
 
     const andClauses: any[] = [];
 
-    if (tagParams.length > 0) {
+    if (proteinSourceParams.length > 0) {
+      // "$in" means something like: proteinSources=Chicken&proteinSources=Tofu
+      // will match recipes with chicken OR tofu OR both.
       andClauses.push({
-        filters: {
-          $all: tagParams.map((tag) => new RegExp(`^${tag}$`, "i")),
-        },
-        allergens: {
-          $all: tagParams.map((tag) => new RegExp(`^${tag}$`, "i")),
-        },
+        proteinSources: { $in: proteinSourceParams },
+      });
+      // If we ever want "chicken AND tofu, should use "$all" instead"
+    }
+
+    // The rest are ANDs. Meaning:
+    // dietary=halal&exclusions=glutenFree
+    // requires halal AND glutenFree
+    for (const dietaryKey of dietaryParams) {
+      andClauses.push({
+        [`dietary.${dietaryKey}`]: true,
+      });
+    }
+
+    for (const exclusionKey of exclusionParams) {
+      andClauses.push({
+        [`exclusions.${exclusionKey}`]: true,
       });
     }
 

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -3,20 +3,13 @@
 import { useRouter } from "next/navigation";
 import MealBrowser from "@/components/MealBrowser";
 import FilterMenu from "@/components/FilterMenu";
-import { CategoryValue, EMPTY_FILTERS, FilterSelections } from "@/lib/types";
+import { CategoryValue, createEmptyFilterSelections, FilterSelections } from "@/lib/types";
 import { useState, useEffect } from "react";
 import { ArrowLeft, Trash2, CircleX, CircleCheck, Menu } from "lucide-react";
 
 import { publishCombos, deleteCombos, deleteRecipes, publishRecipes } from "@/app/actions/draftActions";
 import { useMealData } from "@/hooks/useMealData";
-
-function cloneFilterSelections(f: FilterSelections): FilterSelections {
-  const out: FilterSelections = {};
-  for (const key of Object.keys(f)) {
-    out[key] = new Set(f[key]);
-  }
-  return out;
-}
+import { cloneFilterSelections } from "@/lib/helpers";
 
 export default function DraftsPage() {
   const router = useRouter();
@@ -28,7 +21,7 @@ export default function DraftsPage() {
   const [selectedNames, setSelectedNames] = useState<Record<string, string>>({});
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
   const [search, setSearch] = useState("");
-  const [filters, setFilters] = useState<FilterSelections>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage, refresh } =
     useMealData({

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import MealBrowser from "@/components/MealBrowser";
 import FilterMenu from "@/components/FilterMenu";
-import { CategoryValue, createEmptyFilterSelections, FilterSelections } from "@/lib/types";
+import { CategoryValue, createEmptyFilterSelections, FilterSelections, RecipePreview } from "@/lib/types";
 import { useState, useEffect } from "react";
 import { ArrowLeft, Trash2, CircleX, CircleCheck, Menu } from "lucide-react";
 
@@ -24,11 +24,12 @@ export default function DraftsPage() {
   const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage, refresh } =
-    useMealData({
+    useMealData<RecipePreview>({
       search,
       filters,
       selectedCategories,
       draftMode: true,
+      comboPopulate: "preview",
     });
 
   useEffect(() => {

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 import { DndContext, DragEndEvent, DragStartEvent, DragOverlay, useDroppable } from "@dnd-kit/core";
 import WeekView from "@/components/menuPlanning/WeekView";
@@ -14,7 +14,6 @@ import { ChevronLeft, ChevronRight, ArrowDownToLine, GripVertical, Trash2 } from
 import {
   CalendarDay,
   Combo,
-  EMPTY_FILTERS,
   CategoryValue,
   Nutrition,
   Recipe,
@@ -22,13 +21,13 @@ import {
   RecipeCategory,
   RECIPE_BUCKETS,
   SortOption,
+  createEmptyFilterSelections,
 } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
 import xlsx, { IContent, IJsonSheet } from "json-as-xlsx";
 import { toggleCategory } from "@/lib/helpers";
 
-// TODO: too much code in this file, first fix categories. Later will will find a way to improve.
 const today = new Date();
 
 // Dummy per-day nutrition totals for the week (Mon–Fri), mocking backend data
@@ -40,29 +39,32 @@ const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
   { calories: 390, protein: 25, fat: 10, carbs: 48, fiber: 8, sodium: 530 }, // Fri
 ];
 
+// TODO: refine this a bit. Currently unsure how this is used
 type ActiveDragData = {
-  id: string;
-  type?: string;
-  source?: "sidebar" | "calendar";
+  id: string; // Not the mongo _id... Probably remove
+  type?: string; // Always "recipe" or "trash", but "trash" is a drop zone, can probably remove.
+
+  source?: "sidebar" | "calendar"; // where the item was dragged from
   itemType?: "recipe" | "combo";
 
   recipeId?: string;
   comboId?: string;
-  dayId?: string;
+  dayId?: string; // Used by the calendar drop zone, can probably remove from here then.
 
   name?: string;
   servingSize?: string;
 
-  bucket?: RecipeBucket;
+  // This is the plural of the category. e.g: "entrees", "vegetables"
+  bucket?: RecipeBucket; // now needed in the drag data, can be derived later
   category?: CategoryValue;
-  recipeCategory?: RecipeCategory;
+  recipeCategory?: RecipeCategory; // Simply excludes "combo" when we know it is a recipe
 
   entrees?: string[];
   vegetables?: string[];
   fruits?: string[];
   grains?: string[];
 
-  item?: Recipe | Combo;
+  item?: Recipe | Combo; // We should honestly just include the item and category and forget about the rest of the attributes.
 };
 
 function TrashDropZone() {
@@ -166,6 +168,7 @@ export default function MenuPlanning() {
   const [calendarView, setCalendarView] = useState<"Month" | "Week" | "Day">("Week");
   const [datesOffset, setDatesOffset] = useState(0);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
+  const [filters, setFilters] = useState(() => createEmptyFilterSelections());
 
   const [recipeDropTrigger, setRecipeDropTrigger] = useState(0);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -291,7 +294,7 @@ export default function MenuPlanning() {
 
   const { items, loading, error, currentPage, totalPages, setCurrentPage } = useMealData({
     search,
-    filters: EMPTY_FILTERS,
+    filters, // TODO: can add filtering support to recipeDatabase
     selectedCategories,
     draftMode: false,
     sortBy,

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -8,7 +8,7 @@ import RecipeDatabase from "@/components/menuPlanning/RecipeDatabase";
 import WeeklyNutritionQuota from "@/components/menuPlanning/WeeklyNutritionQuota";
 import DraggableRecipeCard from "@/components/menuPlanning/DraggableRecipeCard";
 import MonthView from "@/components/menuPlanning/MonthView";
-import DayView from "@/components/menuPlanning/DayView";
+import DayView, { DayMealCardPreview } from "@/components/menuPlanning/DayView";
 import CurrentDateButton from "@/components/CurrentDateButton";
 import { ChevronLeft, ChevronRight, ArrowDownToLine, GripVertical, Trash2 } from "lucide-react";
 import {
@@ -23,11 +23,14 @@ import {
   SortOption,
   createEmptyFilterSelections,
   CATEGORY_TO_BUCKET,
+  RecipeNutritionOnly,
 } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
 import xlsx, { IContent, IJsonSheet } from "json-as-xlsx";
 import { toggleCategory } from "@/lib/helpers";
+import DailyNutritionSummary from "@/components/menuPlanning/DailyNutritionSummary";
+import { MonthMealCardPreview } from "@/components/menuPlanning/MonthMealCard";
 
 const today = new Date();
 
@@ -54,7 +57,7 @@ export type SidebarDragData =
 
 export type CalendarDragData = {
   source: "calendar";
-  item: Recipe;
+  item: RecipeNutritionOnly;
   dayId: string;
 };
 
@@ -79,14 +82,16 @@ function TrashDropZone() {
   });
 
   return (
-    <div
-      ref={setNodeRef}
-      className={`flex h-14 w-14 items-center justify-center rounded-full bg-radish-900 text-white shadow-lg transition ${
-        isOver ? "scale-105 ring-4 ring-radish-900/20" : ""
-      }`}
-      aria-label="Trash"
-    >
-      <Trash2 size={24} strokeWidth={2.2} />
+    // some padding around the button to make the droppable area larger
+    <div ref={setNodeRef} className="flex h-24 w-24 items-center justify-center" aria-label="Trash drop zone">
+      <div
+        className={`flex h-14 w-14 items-center justify-center rounded-full bg-radish-900 text-white shadow-lg transition ${
+          isOver ? "scale-105 ring-4 ring-radish-900/20" : ""
+        }`}
+        aria-label="Trash"
+      >
+        <Trash2 size={24} strokeWidth={2.2} />
+      </div>
     </div>
   );
 }
@@ -98,7 +103,7 @@ function SidebarDropZone({ children }: { children: ReactNode }) {
   });
 
   return (
-    <div ref={setNodeRef} className="w-90">
+    <div ref={setNodeRef} className="flex flex-col w-90">
       {children}
     </div>
   );
@@ -199,7 +204,7 @@ export default function MenuPlanning() {
         throw new Error(`Failed to fetch monthly menu: ${res.status}`);
       }
 
-      const dates: CalendarDay[] = await res.json();
+      const dates: CalendarDay<RecipeNutritionOnly>[] = await res.json();
       const data: IContent[] = [];
 
       dates.forEach((date) => {
@@ -236,7 +241,7 @@ export default function MenuPlanning() {
 
         data.push(totals);
 
-        const pushItems = (items: Recipe[] = []) => {
+        const pushItems = (items: RecipeNutritionOnly[] = []) => {
           items.forEach((item) => {
             data.push({
               name: item.name,
@@ -421,10 +426,10 @@ export default function MenuPlanning() {
 
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
-      <main className="flex flex-row">
-        <div className="flex flex-1 items-center justify-center bg-gray-100">
-          <div className="flex h-full w-260 flex-col">
-            <div className="mt-4 flex items-center justify-between">
+      <main className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 justify-center pt-4 bg-gray-100 overflow-auto">
+          <div className="flex w-260 flex-col">
+            <div className="flex items-center justify-between">
               <div className="flex items-center justify-center gap-2">
                 <CurrentDateButton onClick={() => setDatesOffset(0)} />
 
@@ -499,8 +504,8 @@ export default function MenuPlanning() {
             </div>
 
             {calendarView === "Month" && (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <MonthView monthDates={viewDates} dateToday={today} />
+              <>
+                <MonthView monthDates={viewDates} dateToday={today} refetchTrigger={recipeDropTrigger} />
 
                 <div className="mt-2">
                   <WarningQuotaMonthly />
@@ -509,7 +514,7 @@ export default function MenuPlanning() {
                 <div className="mt-auto flex justify-end pb-4">
                   <TrashDropZone />
                 </div>
-              </div>
+              </>
             )}
 
             {calendarView === "Week" && (
@@ -524,7 +529,16 @@ export default function MenuPlanning() {
               </>
             )}
 
-            {calendarView === "Day" && <DayView date={viewDates[0]} refetchTrigger={recipeDropTrigger} />}
+            {calendarView === "Day" && (
+              <>
+                <DayView date={viewDates[0]} refetchTrigger={recipeDropTrigger} />
+                <div className="mt-2 flex justify-end">
+                  <TrashDropZone />
+                </div>
+
+                <DailyNutritionSummary recipes={[]} />
+              </>
+            )}
           </div>
         </div>
 
@@ -547,9 +561,15 @@ export default function MenuPlanning() {
 
       <DragOverlay>
         {activeId ? (
-          <div className="rotate-3 opacity-90">
+          <div className="opacity-80">
             {activeDragData?.source === "calendar" ? (
-              <CalendarDragPreview {...activeDragData} />
+              calendarView === "Month" ? (
+                <MonthMealCardPreview item={activeDragData.item} />
+              ) : calendarView === "Day" ? (
+                <DayMealCardPreview item={activeDragData.item} />
+              ) : (
+                <CalendarDragPreview {...activeDragData} />
+              )
             ) : activeDragData?.item ? (
               <DraggableRecipeCard item={activeDragData.item} disabled />
             ) : null}

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -22,6 +22,7 @@ import {
   RECIPE_BUCKETS,
   SortOption,
   createEmptyFilterSelections,
+  CATEGORY_TO_BUCKET,
 } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
@@ -39,38 +40,42 @@ const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
   { calories: 390, protein: 25, fat: 10, carbs: 48, fiber: 8, sodium: 530 }, // Fri
 ];
 
-// TODO: refine this a bit. Currently unsure how this is used
-type ActiveDragData = {
-  id: string; // Not the mongo _id... Probably remove
-  type?: string; // Always "recipe" or "trash", but "trash" is a drop zone, can probably remove.
+export type SidebarDragData =
+  | {
+      source: "sidebar";
+      itemType: "recipe";
+      item: Recipe;
+    }
+  | {
+      source: "sidebar";
+      itemType: "combo";
+      item: Combo;
+    };
 
-  source?: "sidebar" | "calendar"; // where the item was dragged from
-  itemType?: "recipe" | "combo";
-
-  recipeId?: string;
-  comboId?: string;
-  dayId?: string; // Used by the calendar drop zone, can probably remove from here then.
-
-  name?: string;
-  servingSize?: string;
-
-  // This is the plural of the category. e.g: "entrees", "vegetables"
-  bucket?: RecipeBucket; // now needed in the drag data, can be derived later
-  category?: CategoryValue;
-  recipeCategory?: RecipeCategory; // Simply excludes "combo" when we know it is a recipe
-
-  entrees?: string[];
-  vegetables?: string[];
-  fruits?: string[];
-  grains?: string[];
-
-  item?: Recipe | Combo; // We should honestly just include the item and category and forget about the rest of the attributes.
+export type CalendarDragData = {
+  source: "calendar";
+  item: Recipe;
+  dayId: string;
 };
+
+export type ActiveDragData = SidebarDragData | CalendarDragData;
+
+export type DropZoneData =
+  | {
+      dest: "calendar";
+      dayId: string;
+    }
+  | {
+      dest: "trash";
+    }
+  | {
+      dest: "sidebar";
+    };
 
 function TrashDropZone() {
   const { setNodeRef, isOver } = useDroppable({
-    id: "calendar-trash",
-    data: { type: "trash" },
+    id: "trash",
+    data: { dest: "trash" },
   });
 
   return (
@@ -88,7 +93,7 @@ function TrashDropZone() {
 
 function SidebarDropZone({ children }: { children: ReactNode }) {
   const { setNodeRef } = useDroppable({
-    id: "recipe-sidebar",
+    id: "sidebar",
     data: { type: "sidebar" },
   });
 
@@ -99,17 +104,15 @@ function SidebarDropZone({ children }: { children: ReactNode }) {
   );
 }
 
-function CalendarDragPreview({ name, servingSize, category, recipeCategory }: ActiveDragData) {
-  const displayCategory = category ?? recipeCategory;
-
+function CalendarDragPreview({ item }: CalendarDragData) {
   return (
     <div className="flex w-56 items-center gap-3 rounded-md bg-radish-900 px-4 py-3 font-montserrat text-white shadow-lg">
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[16px] leading-tight font-bold">{name}</p>
-        {servingSize ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{servingSize}</p> : null}
+        <p className="truncate text-[16px] leading-tight font-bold">{item.name}</p>
+        {item.serving ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{item.serving}</p> : null}
       </div>
 
-      {displayCategory ? <span className="shrink-0 text-xs font-medium">{displayCategory}</span> : null}
+      {item.category ? <span className="shrink-0 text-xs font-medium">{item.category}</span> : null}
 
       <GripVertical className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden="true" />
     </div>
@@ -303,8 +306,7 @@ export default function MenuPlanning() {
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveId(event.active.id as string);
     setActiveDragData({
-      id: event.active.id as string,
-      ...(event.active.data.current as Omit<ActiveDragData, "id">),
+      ...(event.active.data.current as ActiveDragData),
     });
   }, []);
 
@@ -316,15 +318,14 @@ export default function MenuPlanning() {
     if (!over) return;
 
     const dragData = active.data.current as ActiveDragData | undefined;
-    const dropData = over.data.current as { type?: string; dayId?: string } | undefined;
+    const dropData = over.data.current as DropZoneData | undefined;
 
-    if (dragData?.type === "recipe" && dragData.source === "calendar" && dropData?.type === "trash") {
-      const { recipeId, dayId, bucket } = dragData;
+    if (!dragData || !dropData) {
+      return;
+    }
 
-      if (!recipeId || !dayId || !bucket) {
-        console.error("Invalid calendar recipe drag data:", dragData);
-        return;
-      }
+    if (dragData.source === "calendar" && dropData.dest === "trash") {
+      const { item, dayId } = dragData;
 
       try {
         const response = await fetch(`/api/calendar/${dayId}`, {
@@ -333,8 +334,8 @@ export default function MenuPlanning() {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            recipeId,
-            category: bucket,
+            recipeId: item._id,
+            category: CATEGORY_TO_BUCKET[item.category],
           }),
         });
 
@@ -352,15 +353,19 @@ export default function MenuPlanning() {
       return;
     }
 
-    if (dragData?.type !== "recipe" || dropData?.type !== "calendar") {
+    if (dropData.dest !== "calendar") {
+      // dropping into the sidebar does nothing
+      // dopping into trash is handled above, dropping into calendar is handled below
       return;
     }
 
     if (dragData.source === "calendar") {
+      // Dragging from the calendar into anywhere else does nothing.
+      // E.g: cannot move a recipe between different days.
       return;
     }
 
-    const { dayId } = dropData;
+    const { dayId } = dropData; // here we are guaranteed to be dropped into calendar
 
     if (!dayId) {
       console.error("Missing calendar day id:", dropData);
@@ -368,15 +373,14 @@ export default function MenuPlanning() {
     }
 
     const calendarItemsToAdd: Array<{ recipeId: string; category: RecipeBucket }> =
+      // if combo, add the recipes in the combo. Otherwise just add the recipe.
       dragData.itemType === "combo"
         ? RECIPE_BUCKETS.flatMap((bucket) =>
-            (dragData[bucket] ?? [])
+            (dragData.item[bucket] ?? [])
               .filter((recipeId): recipeId is string => Boolean(recipeId?.trim()))
               .map((recipeId) => ({ recipeId, category: bucket })),
           )
-        : dragData.recipeId && dragData.bucket
-          ? [{ recipeId: dragData.recipeId, category: dragData.bucket }]
-          : [];
+        : [{ recipeId: dragData.item._id, category: CATEGORY_TO_BUCKET[dragData.item.category] }];
 
     if (calendarItemsToAdd.length === 0) {
       console.error("No valid recipes found in dragged item:", dragData);
@@ -391,10 +395,7 @@ export default function MenuPlanning() {
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({
-              recipeId: item.recipeId,
-              category: item.category,
-            }),
+            body: JSON.stringify(item),
           }),
         ),
       );

--- a/src/app/recipe/page.tsx
+++ b/src/app/recipe/page.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { CategoryValue, EMPTY_FILTERS } from "@/lib/types";
-import { useState } from "react";
-import { useMealData } from "@/hooks/useMealData";
-import { Recipe, Combo } from "@/lib/types";
 import { Suspense } from "react";
-import MealBrowser from "@/components/MealBrowser";
-import FilterMenu from "@/components/FilterMenu";
-import ViewRecipePopUp from "@/components/ViewRecipePopUp";
 import RecipePageClient from "@/components/RecipePageClient";
 
 export default function RecipePage() {

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -2,18 +2,18 @@ import RecipeCard from "@/components/RecipeCard";
 import ComboCard from "@/components/ComboCard";
 import DraftEntryCard from "@/components/DraftEntryCard";
 
-import { Recipe, Combo } from "@/lib/types";
+import { Recipe, Combo, RecipePreview } from "@/lib/types";
 
 type Props = {
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
-  items: Recipe[] | Combo[];
+  items: Recipe[] | Combo<RecipePreview>[];
   draftMode: boolean;
   draftCount: number;
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string, name: string) => void;
-  onOpenItem?: (item: Recipe | Combo) => void;
+  onOpenItem?: (item: Recipe | Combo<RecipePreview>) => void;
 };
 
 // FIXME: layouts are currently sortof broken (max 2 cols for some reason). Figure out why
@@ -39,7 +39,7 @@ export default function CardGrid({
       <div className="grid grid-cols-2 gap-3 md:gap-6 md:max-w-3xl">
         {!draftMode && <DraftEntryCard variant="Combo" numDrafts={draftCount} />}
 
-        {(items as Combo[]).map((combo) => (
+        {(items as Combo<RecipePreview>[]).map((combo) => (
           <ComboCard
             key={combo._id}
             item={combo}

--- a/src/components/CategoryToggle.tsx
+++ b/src/components/CategoryToggle.tsx
@@ -1,3 +1,4 @@
+import PillToggle from "@/components/PillToggle";
 import { CategoryDisplayType, CategoryValue } from "@/lib/types";
 
 export default function CategoryToggle({
@@ -9,27 +10,14 @@ export default function CategoryToggle({
   selectedCategories: Set<CategoryValue>;
   onToggle: (category: CategoryValue) => void;
 }) {
-  const baseClass =
-    "inline-flex items-center rounded-full border border-radish-900 px-3 py-1 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-radish-900";
-  const unselectedClass = "bg-white text-radish-900 hover:bg-radish-100";
-  const selectedClass = "bg-radish-900 text-white";
-
   return (
-    <div className="flex flex-wrap gap-2">
-      {options.map((option) => {
-        const selected = selectedCategories.has(option.category);
-
-        return (
-          <button
-            key={option.category}
-            type="button"
-            onClick={() => onToggle(option.category)}
-            className={`${baseClass} ${selected ? selectedClass : unselectedClass}`}
-          >
-            {option.plural}
-          </button>
-        );
-      })}
-    </div>
+    <PillToggle
+      options={options.map((option) => ({
+        value: option.category,
+        label: option.plural,
+      }))}
+      selectedValues={selectedCategories}
+      onToggle={onToggle}
+    />
   );
 }

--- a/src/components/ComboCard.tsx
+++ b/src/components/ComboCard.tsx
@@ -1,58 +1,57 @@
+"use client";
+
 import Image from "next/image";
 import { Pencil, Utensils } from "lucide-react";
-import { CATEGORY_DISPLAY, Combo, COMBO_CATEGORY_DISPLAY, Recipe, TAG_STYLES } from "@/lib/types";
-import { useEffect, useState } from "react";
+import { COMBO_CATEGORY_DISPLAY, Combo, Recipe, RecipePreview, TAG_STYLES } from "@/lib/types";
+import { useState } from "react";
 import CreateRecipePopUp from "./CreateRecipePopUp";
 
 type ComboCardProps = {
-  item: Combo;
+  item: Combo<RecipePreview>;
   isSelected?: boolean;
   onSelect?: () => void;
   onOpen?: () => void;
 };
 
-export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboCardProps) {
-  const [editMode, setEditMode] = useState(false);
-  const [entreeMap, setEntreeMap] = useState<string[]>([]);
-  const [vegetableMap, setVegetableMap] = useState<string[]>([]);
-  const [fruitMap, setFruitMap] = useState<string[]>([]);
-  const [grainMap, setGrainMap] = useState<string[]>([]);
+async function getCombo(id: string): Promise<Combo<Recipe>> {
+  const res = await fetch(`/api/combos/${id}?populate=all`);
 
-  const entrees = item.entrees ?? [];
-  const vegetables = item.vegetables ?? [];
-  const fruits = item.fruits ?? [];
-  const grains = item.grains ?? [];
-
-  async function getRecipe(id: string): Promise<Recipe> {
-    const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
-    return res.json();
+  if (!res.ok) {
+    throw new Error(`Failed to get combo (${res.status})`);
   }
 
-  useEffect(() => {
-    const loadAll = async () => {
-      try {
-        const [entreeNames, vegetableNames, fruitNames, grainNames] = await Promise.all([
-          Promise.all(entrees.map(async (e) => (await getRecipe(e)).name)),
-          Promise.all(vegetables.map(async (v) => (await getRecipe(v)).name)),
-          Promise.all(fruits.map(async (f) => (await getRecipe(f)).name)),
-          Promise.all(grains.map(async (g) => (await getRecipe(g)).name)),
-        ]);
+  return res.json();
+}
 
-        setEntreeMap(entreeNames);
-        setVegetableMap(vegetableNames);
-        setFruitMap(fruitNames);
-        setGrainMap(grainNames);
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return;
-        console.error("Failed to load combo recipe names:", err);
-      }
-    };
+export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboCardProps) {
+  const [editMode, setEditMode] = useState(false);
+  const [editItem, setEditItem] = useState<Combo<Recipe> | null>(null);
+  const [isLoadingEditItem, setIsLoadingEditItem] = useState(false);
 
-    loadAll();
-  }, []);
+  const recipes = [...(item.entrees ?? []), ...(item.vegetables ?? []), ...(item.fruits ?? []), ...(item.grains ?? [])];
 
   const servingText = item.serving != null ? `${item.serving}` : null;
+
+  const handleEditClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (editItem) {
+      setEditMode(true);
+      return;
+    }
+
+    setIsLoadingEditItem(true);
+
+    try {
+      const fullCombo = await getCombo(item._id);
+      setEditItem(fullCombo);
+      setEditMode(true);
+    } catch (error) {
+      console.error("Failed to load combo for editing:", error);
+    } finally {
+      setIsLoadingEditItem(false);
+    }
+  };
 
   return (
     <div
@@ -70,23 +69,22 @@ export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboC
           <Image src={item.imageUrl} className="h-full w-full object-cover" fill sizes="288px" alt="" />
         ) : null}
 
-        {editMode === true && (
+        {editMode && editItem ? (
           <CreateRecipePopUp
             onClose={() => setEditMode(false)}
-            item={item}
+            item={editItem}
             open={true}
             recipeType={COMBO_CATEGORY_DISPLAY}
             editMode={true}
           />
-        )}
+        ) : null}
 
         {item.isDraft && (
           <Pencil
-            className="absolute top-35 right-4 z-20 h-5 w-5 cursor-pointer rounded-xs accent-radish-900"
-            onClick={(e) => {
-              e.stopPropagation();
-              setEditMode((prev) => !prev);
-            }}
+            className={`absolute top-35 right-4 z-20 h-5 w-5 cursor-pointer rounded-xs accent-radish-900 ${
+              isLoadingEditItem ? "opacity-50" : ""
+            }`}
+            onClick={handleEditClick}
           />
         )}
 
@@ -117,39 +115,14 @@ export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboC
           <p className="mt-3 font-montserrat text-base font-bold">{item.name}</p>
 
           <div className="flex max-h-30 flex-col gap-1.5 overflow-y-auto">
-            {entreeMap.map((i) => (
+            {recipes.map((recipe) => (
               <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Entree}`}
+                key={`${recipe.category}-${recipe._id}`}
+                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${
+                  TAG_STYLES[recipe.category]
+                }`}
               >
-                {i}
-              </span>
-            ))}
-
-            {vegetableMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Vegetable}`}
-              >
-                {i}
-              </span>
-            ))}
-
-            {fruitMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Fruit}`}
-              >
-                {i}
-              </span>
-            ))}
-
-            {grainMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Grain}`}
-              >
-                {i}
+                {recipe.name}
               </span>
             ))}
           </div>

--- a/src/components/CreateRecipePopUp.tsx
+++ b/src/components/CreateRecipePopUp.tsx
@@ -34,8 +34,11 @@ import { DropdownField } from "./createRecipe/DropdownField";
 
 // TODO: this whole thing should be split into Create Combo / Create Recipe subcomponents and helpers should be moved to helpers.ts
 
+type EditableCombo = Combo<Recipe>;
+type EditableItem = Recipe | EditableCombo;
+
 type Props = {
-  item: Recipe | Combo | null;
+  item: EditableItem | null;
   open: boolean;
   onClose: () => void;
   recipeType: CategoryDisplayType | null;
@@ -48,8 +51,15 @@ type InputPair = {
   units: string;
 };
 
-function isRecipeItem(item: Recipe | Combo): item is Recipe {
+function isRecipeItem(item: EditableItem): item is Recipe {
   return "category" in item;
+}
+
+function toRecipeMinimal(recipes: Recipe[] = []): RecipeMinimal[] {
+  return recipes.map((recipe) => ({
+    _id: recipe._id,
+    name: recipe.name,
+  }));
 }
 
 function comboHasRecipe(combo: Combo, recipeId: string) {
@@ -179,12 +189,6 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
     setIngredientInputs(updated);
   };
 
-  async function getRecipe(id: string): Promise<Recipe> {
-    const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
-    return res.json();
-  }
-
   useEffect(() => {
     if (!open) return;
 
@@ -243,41 +247,11 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
           fiber: item.nutritional_info.fiber.toString(),
           sodium: item.nutritional_info.sodium.toString(),
         });
-      } else if (isCombo && isRecipeItem(item) === false) {
-        const loadAll = async () => {
-          const [entreeNames, vegetableNames, fruitNames, grainNames] = await Promise.all([
-            Promise.all(
-              (item.entrees ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.vegetables ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.fruits ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.grains ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-          ]);
-
-          setSelectedEntree(entreeNames);
-          setSelectedVegetables(vegetableNames);
-          setSelectedFruit(fruitNames);
-          setSelectedGrains(grainNames);
-        };
-        loadAll();
+      } else if (isCombo && !isRecipeItem(item)) {
+        setSelectedEntree(toRecipeMinimal(item.entrees));
+        setSelectedVegetables(toRecipeMinimal(item.vegetables));
+        setSelectedFruit(toRecipeMinimal(item.fruits));
+        setSelectedGrains(toRecipeMinimal(item.grains));
       }
 
       setId(item._id);

--- a/src/components/CreateRecipePopUp.tsx
+++ b/src/components/CreateRecipePopUp.tsx
@@ -3,21 +3,34 @@ import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
 import { AlignLeft, ChefHat, ChevronDown, Minus, Plus, Save, Trash2, X, type LucideIcon } from "lucide-react";
 import ImageUploader from "@/components/ImageUploader";
 import {
-  Recipe,
-  Combo,
-  Ingredient,
-  RecipePreview,
-  RecipeCategory,
-  CategoryDisplayType,
+  FILTER_SECTIONS,
   ENTREE_ICON,
   VEGETABLE_ICON,
   FRUIT_ICON,
   GRAIN_ICON,
   FILTER_ICON,
   ALLERGEN_ICON,
+  DIETARY_KEYS,
+  EXCLUSION_KEYS,
 } from "@/lib/types";
-import { FILTER_SECTIONS } from "./FilterMenu";
+import type {
+  Recipe,
+  Combo,
+  Ingredient,
+  RecipeMinimal,
+  RecipeCategory,
+  CategoryDisplayType,
+  DietaryKey,
+  ExclusionKey,
+  FilterOption,
+  ProteinSource,
+  FilterOptionId,
+  FilterSectionId,
+} from "@/lib/types";
 import Image from "next/image";
+import { NutritionalInfo } from "./createRecipe/NutritionalInfo";
+import { FieldRow } from "./createRecipe/FieldRow";
+import { DropdownField } from "./createRecipe/DropdownField";
 
 // TODO: this whole thing should be split into Create Combo / Create Recipe subcomponents and helpers should be moved to helpers.ts
 
@@ -48,197 +61,70 @@ function comboHasRecipe(combo: Combo, recipeId: string) {
   );
 }
 
-function NutritionalInfo({
-  label,
-  unit,
-  value,
-  onChange,
-}: {
-  label: string;
-  unit: string;
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <div className="w-23 rounded-lg border border-pepper/20 bg-white px-2 py-2">
-      {/* top row: value + unit */}
-      <div className="flex items-center justify-center gap-1">
-        <input
-          value={value}
-          onChange={(e) => onChange(e.target.value.replace(/\D/g, ""))}
-          inputMode="numeric"
-          pattern="[0-9]*"
-          placeholder="--"
-          className="w-8 bg-transparent text-center text-sm font-montserrat font-semibold text-pepper outline-none"
-        />
-        <span className="text-sm font-montserrat font-semibold text-pepper/70">{unit}</span>
-      </div>
-
-      {/* bottom row: label */}
-      <div className="mt-1 text-center text-xs font-montserrat font-semibold text-pepper/80">{label}</div>
-    </div>
-  );
+function getFilterSectionOptions(sectionId: FilterSectionId): FilterOption[] {
+  const section = FILTER_SECTIONS.find((section) => section.id === sectionId);
+  return section?.options ?? [];
 }
 
-function FieldRow({
-  icon: Icon,
-  label,
-  value,
-  placeholder,
-  onChange,
-}: {
-  icon: LucideIcon;
-  label: string;
-  value: string;
-  placeholder: string;
-  onChange: (value: string) => void;
-}) {
-  return (
-    <label className="flex items-center justify-between gap-4 rounded-2xl border border-pepper/20 bg-slate-50 px-4 py-3">
-      <div className="flex items-center gap-3 text-sm font-semibold text-pepper">
-        <Icon className="h-5 w-5 text-pepper" strokeWidth={2.2} />
-        <span>{label}</span>
-      </div>
-      <input
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder={placeholder}
-        className="min-w-0 flex-1 rounded-xl border border-pepper/20 bg-white px-3 py-2 text-sm font-montserrat text-pepper outline-none focus:border-pepper/50"
-      />
-    </label>
-  );
+function toggleFilterOption(selectedOptions: FilterOption[], option: FilterOption): FilterOption[] {
+  // check the current toggle status for this option
+  const alreadySelected = selectedOptions.some((selectedOption) => selectedOption.id === option.id);
+
+  if (alreadySelected) {
+    // toggle off
+    return selectedOptions.filter((selectedOption) => selectedOption.id !== option.id);
+  }
+
+  // toggle on
+  return [...selectedOptions, option];
 }
 
-function DropdownField({
-  icon: Icon,
-  label,
-  options,
-  selectedValues,
-  onSelect,
-  placeholder,
-}: {
-  icon: LucideIcon;
-  label: string;
-  options: { id: string; name: string }[];
-  selectedValues: string[];
-  onSelect: (option: { id: string; name: string }) => void;
-  placeholder: string;
-}) {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
-  // close automatically when outside container is clicked on
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex w-full items-center justify-between gap-4 rounded-2xl border border-pepper/20 bg-slate-50 px-4 py-3"
-      >
-        <div className="flex items-center gap-3">
-          <Icon className="h-5 w-5 text-pepper" strokeWidth={2.2} />
-          <span className="text-sm font-semibold text-pepper">{label}</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-pepper/60">
-            {selectedValues.length > 0 ? selectedValues.join(", ") : placeholder}
-          </span>
-          <ChevronDown
-            className={`h-4 w-4 text-pepper transition-transform ${isOpen ? "rotate-180" : ""}`}
-            strokeWidth={2}
-          />
-        </div>
-      </button>
-
-      {isOpen && (
-        <div className="absolute right-0 top-full mt-1 w-full max-h-64 overflow-y-auto rounded-xl border border-pepper/20 bg-white shadow-lg z-10">
-          <div className="p-2">
-            {options.length === 0 ? (
-              <div className="px-3 py-2 text-sm text-pepper/60">{placeholder}</div>
-            ) : (
-              options.map((option) => (
-                <button
-                  key={option.id}
-                  type="button"
-                  onClick={() => {
-                    onSelect(option);
-                  }}
-                  className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-montserrat text-left transition ${
-                    selectedValues.includes(option.name)
-                      ? "bg-pepper/10 text-pepper font-semibold"
-                      : "text-pepper/70 hover:bg-pepper/5"
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedValues.includes(option.name)}
-                    onChange={() => {}}
-                    className="h-4 w-4"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSelect(option);
-                    }}
-                  />
-                  {option.name}
-                </button>
-              ))
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  );
+function optionsToBooleanFlags<TFilterKey extends FilterOptionId>(
+  keys: readonly TFilterKey[],
+  selectedOptions: FilterOption[],
+): Record<TFilterKey, boolean> {
+  const selectedIds = new Set(selectedOptions.map((option) => option.id));
+  return Object.fromEntries(keys.map((key) => [key, selectedIds.has(key)])) as Record<TFilterKey, boolean>;
 }
+
+function flagsToSelectedOptions<TFilterKey extends FilterOptionId>(
+  flags: Partial<Record<TFilterKey, boolean>> | undefined,
+  options: FilterOption[],
+): FilterOption[] {
+  if (!flags) return [];
+
+  return options.filter((option) => flags[option.id as TFilterKey]);
+}
+
+const PROTEIN_SOURCE_OPTIONS = getFilterSectionOptions("proteinSources");
+const DIETARY_OPTIONS = getFilterSectionOptions("dietary");
+const EXCLUSION_OPTIONS = getFilterSectionOptions("exclusions");
+const IS_SUBRECIPE_OPTIONS = [
+  { id: "yes", label: "Yes" },
+  { id: "no", label: "No" },
+];
 
 export default function CreateRecipePopUp({ item, open, onClose, recipeType, editMode }: Props) {
   const createLabel = recipeType?.label ?? "Recipe";
   const isCombo = recipeType?.category === "Combo" || (!!item && !isRecipeItem(item));
 
-  const [selectedEntrees, setSelectedEntree] = useState<RecipePreview[]>([]);
-  const [selectedVegetables, setSelectedVegetables] = useState<RecipePreview[]>([]);
-  const [selectedFruits, setSelectedFruit] = useState<RecipePreview[]>([]);
-  const [selectedGrains, setSelectedGrains] = useState<RecipePreview[]>([]);
-  const [selectedFilters, setSelectedFilters] = useState<{ id: string; name: string }[]>([]);
-  const [selectedAllergens, setSelectedAllergens] = useState<{ id: string; name: string }[]>([]);
+  const [selectedEntrees, setSelectedEntree] = useState<RecipeMinimal[]>([]);
+  const [selectedVegetables, setSelectedVegetables] = useState<RecipeMinimal[]>([]);
+  const [selectedFruits, setSelectedFruit] = useState<RecipeMinimal[]>([]);
+  const [selectedGrains, setSelectedGrains] = useState<RecipeMinimal[]>([]);
+
+  const [selectedProteinSources, setSelectedProteinSources] = useState<FilterOption[]>([]);
+  const [selectedDietary, setSelectedDietary] = useState<FilterOption[]>([]);
+  const [selectedExclusions, setSelectedExclusions] = useState<FilterOption[]>([]);
   const [isSubrecipe, setIsSubrecipe] = useState(false);
 
-  const [entreeOptions, setEntreeOptions] = useState<RecipePreview[]>([]);
-  const [vegetableOptions, setVegetableOptions] = useState<RecipePreview[]>([]);
-  const [fruitOptions, setFruitOptions] = useState<RecipePreview[]>([]);
-  const [grainOptions, setGrainOptions] = useState<RecipePreview[]>([]);
+  const [entreeOptions, setEntreeOptions] = useState<RecipeMinimal[]>([]);
+  const [vegetableOptions, setVegetableOptions] = useState<RecipeMinimal[]>([]);
+  const [fruitOptions, setFruitOptions] = useState<RecipeMinimal[]>([]);
+  const [grainOptions, setGrainOptions] = useState<RecipeMinimal[]>([]);
   const [loadingOptions, setLoadingOptions] = useState(false);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const filterOptions = FILTER_SECTIONS.filter((section) => section.id !== "allergens").flatMap((section) =>
-    section.options.map((option) => ({
-      name: option.label,
-      id: option.label,
-    })),
-  );
-  const allergenOptions = FILTER_SECTIONS.filter((section) => section.id == "allergens").flatMap((section) =>
-    section.options.map((option) => ({
-      name: option.label,
-      id: option.label,
-    })),
-  );
-  const subrecipeOptions = [
-    { id: "yes", name: "Yes" },
-    { id: "no", name: "No" },
-  ];
 
   const [name, setName] = useState("");
   const [imageUrl, setImageUrl] = useState<string>("");
@@ -309,8 +195,10 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
       setSelectedVegetables([]);
       setSelectedFruit([]);
       setSelectedGrains([]);
-      setSelectedFilters([]);
-      setSelectedAllergens([]);
+      setSelectedProteinSources([]);
+      setSelectedDietary([]);
+      setSelectedExclusions([]);
+      setImageUrl("");
       setIsSubrecipe(false);
       setNotes("");
       setServings("1");
@@ -321,18 +209,6 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
     } else {
       setName(item.name);
       setServings(item.serving.toString());
-      setSelectedAllergens(
-        (item.allergens ?? []).map((f) => ({
-          id: f.trim(),
-          name: f.trim(),
-        })),
-      );
-      setSelectedFilters(
-        (item.filters ?? []).map((f) => ({
-          id: f.trim(),
-          name: f.trim(),
-        })),
-      );
       setInstructionsText(item.instructions ?? "");
       setNotes(item.notes ?? "");
       setImageUrl(item.imageUrl ?? "");
@@ -341,6 +217,13 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
 
       // if it's a recipe
       if (!isCombo && isRecipeItem(item) === true) {
+        setSelectedProteinSources(
+          PROTEIN_SOURCE_OPTIONS.filter((option) => item.proteinSources?.includes(option.id as ProteinSource)),
+        );
+
+        setSelectedDietary(flagsToSelectedOptions<DietaryKey>(item.dietary, DIETARY_OPTIONS));
+
+        setSelectedExclusions(flagsToSelectedOptions<ExclusionKey>(item.exclusions, EXCLUSION_OPTIONS));
         setIsSubrecipe(item.isSubrecipe);
         setIngredientInputs(
           item.ingredients
@@ -498,10 +381,10 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
       }
     }
 
-    const filters = selectedFilters
-      .map((filter) => filter.name)
-      .filter(Boolean)
-      .map((filter) => filter.trim());
+    const proteinSources = selectedProteinSources.map((option) => option.id as ProteinSource);
+
+    const dietary = optionsToBooleanFlags(DIETARY_KEYS, selectedDietary);
+    const exclusions = optionsToBooleanFlags(EXCLUSION_KEYS, selectedExclusions);
 
     let payload;
 
@@ -519,9 +402,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
           vegetables: selectedVegetables.map((vegetable) => vegetable._id),
           fruits: selectedFruits.map((fruit) => fruit._id),
           grains: selectedGrains.map((grain) => grain._id),
-          filters: Array.from(new Set(filters)),
           notes: notes,
-          allergens: selectedAllergens.map((allergen) => allergen.name),
           instructions: instructionsText,
           isDraft,
           ...(imageUrl ? { imageUrl } : {}),
@@ -557,8 +438,9 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
           isSubrecipe: isSubrecipe,
           category: recipeCategory,
           serving: Number(servings) || 1,
-          allergens: selectedAllergens.map((allergen) => allergen.name),
-          filters: Array.from(new Set(filters)),
+          proteinSources: Array.from(new Set(proteinSources)),
+          dietary,
+          exclusions,
           ingredients:
             ingredientInputs.length > 0
               ? ingredientInputs
@@ -798,7 +680,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
                 <DropdownField
                   icon={ENTREE_ICON}
                   label="Entree"
-                  options={entreeOptions.map((recipe) => ({ id: recipe._id, name: recipe.name }))}
+                  options={entreeOptions.map((recipe) => ({ id: recipe._id, label: recipe.name }))}
                   selectedValues={selectedEntrees.map((recipe) => recipe.name)}
                   onSelect={(value) => {
                     const selectedOption = entreeOptions.find((recipe) => recipe._id === value.id);
@@ -816,7 +698,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
                 <DropdownField
                   icon={VEGETABLE_ICON}
                   label="Vegetables"
-                  options={vegetableOptions.map((recipe) => ({ id: recipe._id, name: recipe.name }))}
+                  options={vegetableOptions.map((recipe) => ({ id: recipe._id, label: recipe.name }))}
                   selectedValues={selectedVegetables.map((recipe) => recipe.name)}
                   onSelect={(value) => {
                     const selectedOption = vegetableOptions.find((recipe) => recipe._id === value.id);
@@ -834,7 +716,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
                 <DropdownField
                   icon={FRUIT_ICON}
                   label="Fruit"
-                  options={fruitOptions.map((recipe) => ({ id: recipe._id, name: recipe.name }))}
+                  options={fruitOptions.map((recipe) => ({ id: recipe._id, label: recipe.name }))}
                   selectedValues={selectedFruits.map((recipe) => recipe.name)}
                   onSelect={(value) => {
                     const selectedOption = fruitOptions.find((recipe) => recipe._id === value.id);
@@ -852,7 +734,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
                 <DropdownField
                   icon={GRAIN_ICON}
                   label="Grain"
-                  options={grainOptions.map((recipe) => ({ id: recipe._id, name: recipe.name }))}
+                  options={grainOptions.map((recipe) => ({ id: recipe._id, label: recipe.name }))}
                   selectedValues={selectedGrains.map((recipe) => recipe.name)}
                   onSelect={(value) => {
                     const selectedOption = grainOptions.find((recipe) => recipe._id === value.id);
@@ -870,42 +752,52 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
             )}
 
             {!isCombo && (
-              <DropdownField
-                icon={ChefHat}
-                label="Is this a Subrecipe?"
-                options={subrecipeOptions}
-                selectedValues={[isSubrecipe ? "Yes" : "No"]}
-                onSelect={(value) => {
-                  setIsSubrecipe(value.id === "yes");
-                }}
-                placeholder="Select Yes or No"
-              />
+              <>
+                <DropdownField
+                  icon={ChefHat}
+                  label="Is this a Subrecipe?"
+                  options={IS_SUBRECIPE_OPTIONS}
+                  selectedValues={[isSubrecipe ? "Yes" : "No"]}
+                  onSelect={(value) => {
+                    setIsSubrecipe(value.id === "yes");
+                  }}
+                  placeholder="Select Yes or No"
+                />
+                <DropdownField
+                  icon={FILTER_ICON}
+                  label="Protein Sources"
+                  options={PROTEIN_SOURCE_OPTIONS}
+                  selectedValues={selectedProteinSources.map((option) => option.label)}
+                  onSelect={(option) => {
+                    setSelectedProteinSources((prev) => toggleFilterOption(prev, option as FilterOption));
+                  }}
+                  placeholder="Select Protein Source(s)"
+                />
+
+                <DropdownField
+                  icon={FILTER_ICON}
+                  label="Dietary"
+                  options={DIETARY_OPTIONS}
+                  selectedValues={selectedDietary.map((option) => option.label)}
+                  onSelect={(option) => {
+                    setSelectedDietary((prev) => toggleFilterOption(prev, option as FilterOption));
+                  }}
+                  placeholder="Select Dietary Option(s)"
+                />
+
+                <DropdownField
+                  icon={ALLERGEN_ICON}
+                  label="Allergens / Exclusions"
+                  options={EXCLUSION_OPTIONS}
+                  selectedValues={selectedExclusions.map((option) => option.label)}
+                  onSelect={(option) => {
+                    setSelectedExclusions((prev) => toggleFilterOption(prev, option as FilterOption));
+                  }}
+                  placeholder="Select Exclusion(s)"
+                />
+              </>
             )}
 
-            <DropdownField
-              icon={FILTER_ICON}
-              label="Filters"
-              options={filterOptions}
-              selectedValues={selectedFilters.map((f) => f.name)}
-              onSelect={(value) => {
-                setSelectedFilters((prev) =>
-                  prev.some((a) => a.id === value.id) ? prev.filter((a) => a.id !== value.id) : [...prev, value],
-                );
-              }}
-              placeholder="Select Filter(s)"
-            />
-            <DropdownField
-              icon={ALLERGEN_ICON}
-              label="Allergens"
-              options={allergenOptions}
-              selectedValues={selectedAllergens.map((f) => f.name)}
-              onSelect={(value) => {
-                setSelectedAllergens((prev) =>
-                  prev.some((a) => a.id === value.id) ? prev.filter((a) => a.id !== value.id) : [...prev, value],
-                );
-              }}
-              placeholder="Select Allergen(s)"
-            />
             <FieldRow icon={AlignLeft} label="Notes" value={notes} placeholder="Add notes" onChange={setNotes} />
           </div>
 

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -1,18 +1,15 @@
 import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import FilterTag from "./FilterTag";
-import { FilterSelections } from "@/lib/types";
-
-export type FilterOption = {
-  id: string;
-  label: string;
-};
-
-export type FilterSection = {
-  id: string;
-  label: string;
-  options: FilterOption[];
-};
+import {
+  createEmptyFilterSelections,
+  FILTER_SECTIONS,
+  FilterOption,
+  FilterOptionId,
+  FilterSection,
+  FilterSectionId,
+  FilterSelections,
+} from "@/lib/types";
 
 type FilterMenuProps = {
   onFilterChange?: (selections: FilterSelections) => void;
@@ -22,74 +19,22 @@ type FilterMenuProps = {
   mobileOverlay?: { onClose: () => void };
 };
 
-// TODO: these should be enforced by a type in types.ts
-export const FILTER_SECTIONS: FilterSection[] = [
-  {
-    id: "allergens",
-    label: "Allergens / Exclusions",
-    options: [
-      { id: "dairy-free", label: "Dairy-Free" },
-      { id: "gluten-free", label: "Gluten-Free" },
-      { id: "nut-free", label: "Nut-Free" },
-      { id: "soy-free", label: "Soy-Free" },
-      { id: "shellfish-free", label: "Shellfish-Free" },
-    ],
-  },
-  {
-    id: "proteins",
-    label: "Proteins",
-    options: [
-      { id: "chicken", label: "Chicken" },
-      { id: "beef", label: "Beef" },
-      { id: "fish", label: "Fish" },
-      { id: "tofu", label: "Tofu" },
-      { id: "beans", label: "Beans" },
-    ],
-  },
-  {
-    id: "vitamins",
-    label: "Vitamins / Minerals",
-    options: [
-      { id: "iron", label: "Iron" },
-      { id: "vitamin-a", label: "Vitamin A" },
-      { id: "vitamin-c", label: "Vitamin C" },
-      { id: "calcium", label: "Calcium" },
-      { id: "potassium", label: "Potassium" },
-    ],
-  },
-  {
-    id: "dietary",
-    label: "Dietary Preferences",
-    options: [
-      { id: "vegetarian", label: "Vegetarian" },
-      { id: "vegan", label: "Vegan" },
-      { id: "halal", label: "Halal" },
-      { id: "kosher", label: "Kosher" },
-      { id: "low-sodium", label: "Low Sodium" },
-    ],
-  },
-  {
-    id: "additional",
-    label: "Additional Filters",
-    options: [{ id: "isSubrecipe", label: "Subrecipes Only" }],
-  },
-];
-
 function emptySelections(): FilterSelections {
-  return FILTER_SECTIONS.reduce<FilterSelections>((acc, section) => {
-    acc[section.id] = new Set();
-    return acc;
-  }, {});
+  return createEmptyFilterSelections();
 }
 
 function mergeSelections(initial?: FilterSelections): FilterSelections {
-  const base = emptySelections();
+  const base = createEmptyFilterSelections();
+
   if (!initial) return base;
-  for (const key of Object.keys(base)) {
-    const s = initial[key];
-    if (s) base[key] = new Set(s);
-  }
-  return base;
+
+  return {
+    proteinSources: new Set(initial.proteinSources),
+    dietary: new Set(initial.dietary),
+    exclusions: new Set(initial.exclusions),
+    servings: new Set(initial.servings),
+    additional: new Set(initial.additional),
+  };
 }
 
 export default function FilterMenu({ onFilterChange, initialSelections, mobileOverlay }: FilterMenuProps) {
@@ -105,7 +50,7 @@ export default function FilterMenu({ onFilterChange, initialSelections, mobileOv
     onFilterChangeRef.current?.(selections);
   }, [mobileOverlay, selections]);
 
-  const handleToggleOption = (sectionId: string, optionId: string) => {
+  const handleToggleOption = (sectionId: FilterSectionId, optionId: FilterOptionId) => {
     setSelections((prev) => {
       const next: FilterSelections = { ...prev };
       const nextSet = new Set(next[sectionId] ?? []);
@@ -117,6 +62,7 @@ export default function FilterMenu({ onFilterChange, initialSelections, mobileOv
       }
 
       next[sectionId] = nextSet;
+
       return next;
     });
   };
@@ -232,9 +178,9 @@ function FilterMenuOption({
 }: {
   label: string;
   options: FilterOption[];
-  selections?: Set<string>;
+  selections?: Set<FilterOptionId>;
   defaultExpanded: boolean;
-  onToggle: (optionId: string) => void;
+  onToggle: (optionId: FilterOptionId) => void;
 }) {
   const [isOpen, setIsOpen] = useState(defaultExpanded);
 

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -4,12 +4,12 @@ import CategoryToggle from "@/components/CategoryToggle";
 import CardGrid from "@/components/CardGrid";
 import AddNewRecipeButton from "@/components/AddNewRecipeButton";
 import PaginationDisplay from "@/components/PaginationDisplay";
-import { CATEGORY_DISPLAY, CategoryValue, Combo, Recipe } from "@/lib/types";
+import { CATEGORY_DISPLAY, CategoryValue, Combo, Recipe, RecipePreview } from "@/lib/types";
 import { toggleCategory } from "@/lib/helpers";
 
 type Props = {
   setSearch: (s: string) => void;
-  items: Recipe[] | Combo[];
+  items: Recipe[] | Combo<RecipePreview>[];
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
@@ -24,7 +24,7 @@ type Props = {
 
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string, name: string) => void;
-  onOpenItem?: (item: Recipe | Combo) => void;
+  onOpenItem?: (item: Recipe | Combo<RecipePreview>) => void;
 
   topLeftChildren?: ReactNode; // top-left slot for an extra button
   topRightChildren?: ReactNode; // for additional buttons after search bar

--- a/src/components/MobileFilterDisplay.tsx
+++ b/src/components/MobileFilterDisplay.tsx
@@ -1,9 +1,8 @@
 import { ChevronDown, SlidersHorizontal, X } from "lucide-react";
 import { useState, useMemo } from "react";
 import FilterTag from "./FilterTag";
-import { FILTER_SECTIONS } from "./FilterMenu"; // TODO: if these are types thhey should go in types.ts
-import type { FilterOption } from "./FilterMenu";
-import type { FilterSelections } from "@/lib/types";
+import { FILTER_SECTIONS } from "@/lib/types";
+import type { FilterOption, FilterSelections } from "@/lib/types";
 
 type MobileFilterDisplayProps = {
   selections: FilterSelections;

--- a/src/components/PermissionsClient.tsx
+++ b/src/components/PermissionsClient.tsx
@@ -1,35 +1,101 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import SearchBarClient from "@/components/SearchbarClient";
 import PermissionsDisplay from "@/components/PermissionsDisplay";
 import SortPermissionsButton from "@/components/SortPermissionsButton";
+import PaginationDisplay from "@/components/PaginationDisplay";
+import PillToggle from "@/components/PillToggle";
+import { USER_ROLES, type UserRole } from "@/lib/types";
 import { UserPerms } from "@/components/IndividualPermission";
 
 interface PermissionsClientProps {
   users: UserPerms[];
 }
 
+const PAGE_SIZE = 5;
+
 export default function PermissionsClient({ users }: PermissionsClientProps) {
   const [search, setSearch] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedRoles, setSelectedRoles] = useState<Set<UserRole>>(new Set());
 
+  /* TODO: Delete this local filtering/pagination once permissions are fetched from the API.
+   * Eventually the API should receive: search, selectedRoles, currentPage, PAGE_SIZE.
+   */
   const filteredUsers = useMemo(() => {
     const query = search.trim().toLowerCase();
-    if (!query) return users;
 
     return users.filter((user) => {
-      const parts = user.name.toLowerCase().split(" ");
-      return parts.some((part) => part.includes(query)) || user.name.toLowerCase().includes(query);
+      const name = user.name.toLowerCase();
+      const matchesSearch = !query || name.includes(query) || name.split(" ").some((part) => part.includes(query));
+
+      const matchesRole = selectedRoles.size === 0 || selectedRoles.has(user.role as UserRole);
+
+      return matchesSearch && matchesRole;
     });
-  }, [search, users]);
+  }, [search, selectedRoles, users]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredUsers.length / PAGE_SIZE));
+
+  const paginatedUsers = useMemo(() => {
+    const startIndex = (currentPage - 1) * PAGE_SIZE;
+    const endIndex = startIndex + PAGE_SIZE;
+
+    return filteredUsers.slice(startIndex, endIndex);
+  }, [filteredUsers, currentPage]);
+  /* End temporary local filtering/pagination */
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [search, selectedRoles]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const toggleRole = (role: UserRole) => {
+    setSelectedRoles((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(role)) {
+        next.delete(role);
+      } else {
+        next.add(role);
+      }
+
+      return next;
+    });
+  };
 
   return (
     <div className="p-5">
-      <div className="flex items-center gap-3 mb-5">
+      <div className="mb-5 flex items-center gap-3">
         <SearchBarClient placeholder="Search a user" onSearch={setSearch} />
         <SortPermissionsButton align="right" />
       </div>
-      <PermissionsDisplay users={filteredUsers} editing={true} />
+
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <PillToggle
+          options={USER_ROLES.map((role) => ({
+            value: role,
+            label: role,
+          }))}
+          selectedValues={selectedRoles}
+          onToggle={toggleRole}
+        />
+
+        <PaginationDisplay
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+          disabled={false}
+        />
+      </div>
+
+      <PermissionsDisplay users={paginatedUsers} editing={true} />
     </div>
   );
 }

--- a/src/components/PillToggle.tsx
+++ b/src/components/PillToggle.tsx
@@ -1,0 +1,36 @@
+type PillToggleOption<T extends string> = {
+  value: T;
+  label: string;
+};
+
+type PillToggleProps<T extends string> = {
+  options: PillToggleOption<T>[];
+  selectedValues: Set<T>;
+  onToggle: (value: T) => void;
+};
+
+export default function PillToggle<T extends string>({ options, selectedValues, onToggle }: PillToggleProps<T>) {
+  const baseClass =
+    "inline-flex items-center rounded-full border border-radish-900 px-3 py-1 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-radish-900";
+  const unselectedClass = "bg-white text-radish-900 hover:bg-radish-100";
+  const selectedClass = "bg-radish-900 text-white";
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const selected = selectedValues.has(option.value);
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onToggle(option.value)}
+            className={`${baseClass} ${selected ? selectedClass : unselectedClass}`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/RecipeDailyCard.tsx
+++ b/src/components/RecipeDailyCard.tsx
@@ -4,7 +4,7 @@ import { Recipe, TAG_STYLES } from "@/lib/types";
 
 export type RecipeCardProps = {
   item: Recipe;
-  onOpen?: () => void; // TODO: is this used for anything?
+  onOpen?: () => void;
 };
 
 export default function RecipeDailyCard({ item, onOpen }: RecipeCardProps) {

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -8,7 +8,7 @@ import {
   CategoryDisplayType,
   CategoryValue,
   COMBO_CATEGORY_DISPLAY,
-  EMPTY_FILTERS,
+  createEmptyFilterSelections,
   FilterSelections,
 } from "@/lib/types";
 import { useEffect, useState } from "react";
@@ -16,20 +16,13 @@ import { useMealData } from "@/hooks/useMealData";
 import { Recipe, Combo } from "@/lib/types";
 import { SlidersHorizontal } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-
-function cloneFilterSelections(f: FilterSelections): FilterSelections {
-  const out: FilterSelections = {};
-  for (const key of Object.keys(f)) {
-    out[key] = new Set(f[key]);
-  }
-  return out;
-}
+import { cloneFilterSelections } from "@/lib/helpers";
 
 export default function RecipePageClient() {
   const searchParams = useSearchParams();
   const id = searchParams.get("id");
 
-  const [filters, setFilters] = useState<FilterSelections>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
   const [search, setSearch] = useState("");

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -10,6 +10,7 @@ import {
   COMBO_CATEGORY_DISPLAY,
   createEmptyFilterSelections,
   FilterSelections,
+  RecipePreview,
 } from "@/lib/types";
 import { useEffect, useState } from "react";
 import { useMealData } from "@/hooks/useMealData";
@@ -18,41 +19,79 @@ import { SlidersHorizontal } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { cloneFilterSelections } from "@/lib/helpers";
 
+type BrowserItem = Recipe | Combo<RecipePreview>;
+type SelectedItem = Recipe | Combo<Recipe>;
+
+function isRecipe(item: BrowserItem | SelectedItem): item is Recipe {
+  return "category" in item;
+}
+
 export default function RecipePageClient() {
   const searchParams = useSearchParams();
   const id = searchParams.get("id");
 
-  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
+  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections());
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
   const [search, setSearch] = useState("");
-  const [selectedItem, setSelectedItem] = useState<Recipe | Combo | null>(null);
+  const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [activeType, setActiveType] = useState<CategoryDisplayType | null>(null);
 
   async function getRecipe(id: string): Promise<Recipe> {
     const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
+
+    if (!res.ok) {
+      throw new Error(`Failed to get individual recipe (${res.status})`);
+    }
+
     return res.json();
   }
 
-  const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage } = useMealData({
-    search,
-    filters,
-    selectedCategories,
-    draftMode: false,
-  });
+  async function getCombo(id: string): Promise<Combo<Recipe>> {
+    const res = await fetch(`/api/combos/${id}?populate=all`);
 
-  const handleOpenItem = (item: Recipe | Combo) => {
-    setSelectedItem(item);
-    setIsOpen(true);
-    setActiveType(isComboMode ? COMBO_CATEGORY_DISPLAY : null);
+    if (!res.ok) {
+      throw new Error(`Failed to get individual combo (${res.status})`);
+    }
+
+    return res.json();
+  }
+
+  const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage } =
+    useMealData<RecipePreview>({
+      search,
+      filters,
+      selectedCategories,
+      draftMode: false,
+      comboPopulate: "preview",
+    });
+
+  const handleOpenItem = async (item: BrowserItem) => {
+    setMode("view");
+
+    if (isRecipe(item)) {
+      setSelectedItem(item);
+      setActiveType(null);
+      setIsOpen(true);
+      return;
+    }
+
+    try {
+      const combo = await getCombo(item._id);
+
+      setSelectedItem(combo);
+      setActiveType(COMBO_CATEGORY_DISPLAY);
+      setIsOpen(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   useEffect(() => {
-    if (!id || id === "") return;
-    // fetch recipe item
+    if (!id) return;
+
     getRecipe(id)
       .then((recipe) => {
         setSelectedItem(recipe);
@@ -64,6 +103,8 @@ export default function RecipePageClient() {
         console.error(err);
       });
   }, [id]);
+
+  const selectedItemIsCombo = selectedItem ? !isRecipe(selectedItem) : isComboMode;
 
   return (
     <main className="relative flex min-h-0 flex-1 flex-col gap-6 overflow-hidden px-5 pt-5 md:flex-row">
@@ -116,7 +157,7 @@ export default function RecipePageClient() {
           open={isOpen}
           onClose={setIsOpen}
           item={selectedItem}
-          isComboMode={isComboMode}
+          isComboMode={selectedItemIsCombo}
           changeMode={(e) => setMode(e)}
         />
       ) : (

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -136,9 +136,6 @@ export default function ViewRecipePopUp({ open, onClose, item, isComboMode, chan
   const [maximized, setMaximized] = useState(false);
   const [servings, setServings] = useState(item?.serving || 1);
 
-  // TODO: Ideally the filters are displayedd the same way. Make a "flattenFilters" helper
-  // to flatten the filter object to a list.
-
   useEffect(() => {
     if (open && item?.serving) {
       setServings(item.serving);

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -1,8 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { TAG_STYLES } from "@/lib/types";
-import type { Combo, CategoryValue, Nutrition, Recipe, RecipeCategory } from "@/lib/types";
+import { DIETARY_KEYS, EXCLUSION_KEYS, FILTER_SECTIONS, TAG_STYLES } from "@/lib/types";
+import type {
+  Combo,
+  CategoryValue,
+  FilterOptionId,
+  MealFilterFields,
+  Nutrition,
+  Recipe,
+  RecipeCategory,
+} from "@/lib/types";
 import {
   ArrowLeft,
   Maximize2,
@@ -112,9 +120,24 @@ function getComboNutrition(comboRecipes: ComboRecipeMap, comboServing: number): 
   return scaleNutrition(nutritionPerServing, Math.max(1, comboServing));
 }
 
+const FILTER_LABEL_BY_ID = new Map(
+  FILTER_SECTIONS.flatMap((section) => section.options.map((option) => [option.id, option.label] as const)),
+);
+
+function getFilterLabel(id: FilterOptionId): string {
+  return FILTER_LABEL_BY_ID.get(id) ?? id;
+}
+
+function selectedFlagLabels<TId extends FilterOptionId>(flags: Record<TId, boolean>, keys: readonly TId[]): string[] {
+  return keys.filter((key) => flags[key]).map(getFilterLabel);
+}
+
 export default function ViewRecipePopUp({ open, onClose, item, isComboMode, changeMode }: Props) {
   const [maximized, setMaximized] = useState(false);
   const [servings, setServings] = useState(item?.serving || 1);
+
+  // TODO: Ideally the filters are displayedd the same way. Make a "flattenFilters" helper
+  // to flatten the filter object to a list.
 
   useEffect(() => {
     if (open && item?.serving) {
@@ -209,8 +232,7 @@ function RecipeDetails({
         {recipe.isSubrecipe ? <Chip label="Subrecipe" /> : null}
       </LabeledSection>
 
-      <TagListSection label="Filters" icon={<Tag />} items={recipe.filters} />
-      <TagListSection label="Allergens" icon={<CircleAlert />} items={recipe.allergens} />
+      <MealFiltersSection item={recipe} />
 
       {recipe.notes ? (
         <LabeledSection label="Notes" icon={<SquarePen />}>
@@ -302,8 +324,7 @@ function ComboDetails({
       <RecipeGroup label="Fruits" icon={<Apple />} items={comboRecipes.fruits} styleKey="Fruit" />
       <RecipeGroup label="Grains" icon={<Tag />} items={comboRecipes.grains} styleKey="Grain" />
 
-      <TagListSection label="Filters" icon={<Tag />} items={combo.filters} />
-      <TagListSection label="Allergens" icon={<CircleAlert />} items={combo.allergens} />
+      <MealFiltersSection item={combo} />
 
       {combo.notes ? (
         <LabeledSection label="Notes" icon={<SquarePen />}>
@@ -357,6 +378,20 @@ function RecipeGroup({
   );
 }
 
+function MealFiltersSection({ item }: { item: MealFilterFields }) {
+  const proteinSourceLabels = item.proteinSources.map(getFilterLabel);
+  const dietaryLabels = selectedFlagLabels(item.dietary, DIETARY_KEYS);
+  const exclusionLabels = selectedFlagLabels(item.exclusions, EXCLUSION_KEYS);
+
+  return (
+    <>
+      <TagListSection label="Protein Sources" icon={<Tag />} items={proteinSourceLabels} />
+      <TagListSection label="Dietary" icon={<Tag />} items={dietaryLabels} />
+      <TagListSection label="Exclusions" icon={<CircleAlert />} items={exclusionLabels} />
+    </>
+  );
+}
+
 function TagListSection({ label, icon, items }: { label: string; icon: ReactNode; items?: string[] }) {
   if (!items?.length) return null;
 
@@ -374,7 +409,7 @@ function TagListSection({ label, icon, items }: { label: string; icon: ReactNode
 function LabeledSection({ label, icon, children }: { label: string; icon: ReactNode; children: ReactNode }) {
   return (
     <div className="mb-4 flex">
-      <h3 className="flex w-30 shrink-0 gap-2 py-1 font-bold">
+      <h3 className="flex w-42 shrink-0 gap-2 py-1 text-nowrap font-bold">
         {icon}
         {label}
       </h3>

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { DIETARY_KEYS, EXCLUSION_KEYS, FILTER_SECTIONS, TAG_STYLES } from "@/lib/types";
+import {
+  DIETARY_KEYS,
+  ENTREE_ICON,
+  EXCLUSION_KEYS,
+  FILTER_SECTIONS,
+  FRUIT_ICON,
+  GRAIN_ICON,
+  RECIPE_BUCKETS,
+  TAG_STYLES,
+  VEGETABLE_ICON,
+} from "@/lib/types";
 import type {
   Combo,
   CategoryValue,
@@ -9,6 +19,7 @@ import type {
   MealFilterFields,
   Nutrition,
   Recipe,
+  RecipeBuckets,
   RecipeCategory,
 } from "@/lib/types";
 import {
@@ -16,8 +27,6 @@ import {
   Maximize2,
   Pencil,
   Ellipsis,
-  Carrot,
-  Apple,
   Tag,
   CircleAlert,
   SquarePen,
@@ -31,23 +40,9 @@ import NutritionalInfo from "./NutrionalInfo";
 type Props = {
   open: boolean;
   onClose: (v: boolean) => void;
-  item: Recipe | Combo | null;
+  item: Recipe | Combo<Recipe> | null;
   isComboMode: boolean;
   changeMode: (mode: "view" | "edit") => void;
-};
-
-type ComboRecipeMap = {
-  entrees: Recipe[];
-  vegetables: Recipe[];
-  fruits: Recipe[];
-  grains: Recipe[];
-};
-
-const EMPTY_COMBO_RECIPE_MAP: ComboRecipeMap = {
-  entrees: [],
-  vegetables: [],
-  fruits: [],
-  grains: [],
 };
 
 function emptyNutrition(): Nutrition {
@@ -88,27 +83,8 @@ function formatNutritionValue(value: number, originalServings: number, servings:
   return Number.isInteger(scaled) ? scaled.toString() : scaled.toFixed(1);
 }
 
-async function getRecipe(id: string, signal?: AbortSignal): Promise<Recipe> {
-  const res = await fetch(`/api/recipes/${id}`, { signal });
-
-  if (!res.ok) {
-    throw new Error(`Failed to get individual recipe (${res.status})`);
-  }
-
-  return res.json();
-}
-
-async function getRecipes(ids: string[] = [], signal?: AbortSignal): Promise<Recipe[]> {
-  return Promise.all(ids.map((id) => getRecipe(id, signal)));
-}
-
-function getComboNutrition(comboRecipes: ComboRecipeMap, comboServing: number): Nutrition {
-  const allRecipes = [
-    ...comboRecipes.entrees,
-    ...comboRecipes.vegetables,
-    ...comboRecipes.fruits,
-    ...comboRecipes.grains,
-  ];
+function getComboNutrition(comboRecipes: RecipeBuckets<Recipe>, comboServing: number): Nutrition {
+  const allRecipes = RECIPE_BUCKETS.flatMap((bucket) => comboRecipes[bucket] ?? []);
 
   const nutritionPerServing = allRecipes.reduce((total, recipe) => {
     const recipeServing = Math.max(1, recipe.serving || 1);
@@ -189,7 +165,7 @@ export default function ViewRecipePopUp({ open, onClose, item, isComboMode, chan
 
             {isComboMode ? (
               <ComboDetails
-                combo={item as Combo}
+                combo={item as Combo<Recipe>}
                 servings={servings}
                 setServings={setServings}
                 originalServings={originalServings}
@@ -272,54 +248,19 @@ function ComboDetails({
   setServings,
   originalServings,
 }: {
-  combo: Combo;
+  combo: Combo<Recipe>;
   servings: number;
   setServings: React.Dispatch<React.SetStateAction<number>>;
   originalServings: number;
 }) {
-  const [comboRecipes, setComboRecipes] = useState<ComboRecipeMap>(EMPTY_COMBO_RECIPE_MAP);
-
-  const nutrition = useMemo(() => getComboNutrition(comboRecipes, combo.serving), [comboRecipes, combo.serving]);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    async function loadComboRecipes() {
-      try {
-        setComboRecipes(EMPTY_COMBO_RECIPE_MAP);
-
-        const [entrees, vegetables, fruits, grains] = await Promise.all([
-          getRecipes(combo.entrees, controller.signal),
-          getRecipes(combo.vegetables, controller.signal),
-          getRecipes(combo.fruits, controller.signal),
-          getRecipes(combo.grains, controller.signal),
-        ]);
-
-        setComboRecipes({
-          entrees,
-          vegetables,
-          fruits,
-          grains,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return;
-
-        console.error("Failed to load combo recipes:", err);
-        setComboRecipes(EMPTY_COMBO_RECIPE_MAP);
-      }
-    }
-
-    loadComboRecipes();
-
-    return () => controller.abort();
-  }, [combo]);
+  const nutrition = useMemo(() => getComboNutrition(combo, combo.serving), [combo]);
 
   return (
     <>
-      <RecipeGroup label="Entrees" icon={<Carrot />} items={comboRecipes.entrees} styleKey="Entree" />
-      <RecipeGroup label="Vegetables" icon={<Carrot />} items={comboRecipes.vegetables} styleKey="Vegetable" />
-      <RecipeGroup label="Fruits" icon={<Apple />} items={comboRecipes.fruits} styleKey="Fruit" />
-      <RecipeGroup label="Grains" icon={<Tag />} items={comboRecipes.grains} styleKey="Grain" />
+      <RecipeGroup label="Entrees" icon={<ENTREE_ICON />} items={combo.entrees} styleKey="Entree" />
+      <RecipeGroup label="Vegetables" icon={<VEGETABLE_ICON />} items={combo.vegetables} styleKey="Vegetable" />
+      <RecipeGroup label="Fruits" icon={<FRUIT_ICON />} items={combo.fruits} styleKey="Fruit" />
+      <RecipeGroup label="Grains" icon={<GRAIN_ICON />} items={combo.grains} styleKey="Grain" />
 
       <MealFiltersSection item={combo} />
 

--- a/src/components/createRecipe/DropdownField.tsx
+++ b/src/components/createRecipe/DropdownField.tsx
@@ -1,0 +1,96 @@
+import { ChevronDown, type LucideIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+export function DropdownField({
+  icon: Icon,
+  label,
+  options,
+  selectedValues,
+  onSelect,
+  placeholder,
+}: {
+  icon: LucideIcon;
+  label: string;
+  options: { id: string; label: string }[];
+  selectedValues: string[];
+  onSelect: (option: { id: string; label: string }) => void;
+  placeholder: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // close automatically when outside container is clicked on
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex w-full items-center justify-between gap-4 rounded-2xl border border-pepper/20 bg-slate-50 px-4 py-3"
+      >
+        <div className="flex items-center gap-3">
+          <Icon className="h-5 w-5 text-pepper" strokeWidth={2.2} />
+          <span className="text-sm font-semibold text-pepper">{label}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-pepper/60">
+            {selectedValues.length > 0 ? selectedValues.join(", ") : placeholder}
+          </span>
+          <ChevronDown
+            className={`h-4 w-4 text-pepper transition-transform ${isOpen ? "rotate-180" : ""}`}
+            strokeWidth={2}
+          />
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-1 w-full max-h-64 overflow-y-auto rounded-xl border border-pepper/20 bg-white shadow-lg z-10">
+          <div className="p-2">
+            {options.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-pepper/60">{placeholder}</div>
+            ) : (
+              options.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => {
+                    onSelect(option);
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-montserrat text-left transition ${
+                    selectedValues.includes(option.label)
+                      ? "bg-pepper/10 text-pepper font-semibold"
+                      : "text-pepper/70 hover:bg-pepper/5"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedValues.includes(option.label)}
+                    onChange={() => {}}
+                    className="h-4 w-4"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect(option);
+                    }}
+                  />
+                  {option.label}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/createRecipe/FieldRow.tsx
+++ b/src/components/createRecipe/FieldRow.tsx
@@ -1,0 +1,30 @@
+import type { LucideIcon } from "lucide-react";
+
+export function FieldRow({
+  icon: Icon,
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-4 rounded-2xl border border-pepper/20 bg-slate-50 px-4 py-3">
+      <div className="flex items-center gap-3 text-sm font-semibold text-pepper">
+        <Icon className="h-5 w-5 text-pepper" strokeWidth={2.2} />
+        <span>{label}</span>
+      </div>
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="min-w-0 flex-1 rounded-xl border border-pepper/20 bg-white px-3 py-2 text-sm font-montserrat text-pepper outline-none focus:border-pepper/50"
+      />
+    </label>
+  );
+}

--- a/src/components/createRecipe/NutritionalInfo.tsx
+++ b/src/components/createRecipe/NutritionalInfo.tsx
@@ -1,33 +1,33 @@
-function NutritionalInfo({
+import React from "react";
+
+export function NutritionalInfo({
   label,
   unit,
   value,
   onChange,
-  readOnly,
 }: {
   label: string;
   unit: string;
   value: string;
   onChange: (v: string) => void;
-  readOnly: boolean;
 }) {
   return (
-    <div className="w-27.5 rounded-lg border border-pepper/20 bg-white px-2 py-2">
+    <div className="w-23 rounded-lg border border-pepper/20 bg-white px-2 py-2">
+      {/* top row: value + unit */}
       <div className="flex items-center justify-center gap-1">
         <input
           value={value}
-          onChange={(e) => !readOnly && onChange?.(e.target.value.replace(/\D/g, ""))}
+          onChange={(e) => onChange(e.target.value.replace(/\D/g, ""))}
           inputMode="numeric"
           pattern="[0-9]*"
           placeholder="--"
           className="w-8 bg-transparent text-center text-sm font-montserrat font-semibold text-pepper outline-none"
-          readOnly={readOnly}
         />
         <span className="text-sm font-montserrat font-semibold text-pepper/70">{unit}</span>
       </div>
 
+      {/* bottom row: label */}
       <div className="mt-1 text-center text-xs font-montserrat font-semibold text-pepper/80">{label}</div>
     </div>
   );
 }
-export default NutritionalInfo;

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -1,28 +1,28 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Trash2 } from "lucide-react";
+import { GripVertical, Trash2 } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
 import DroppableCalendarArea from "./DroppableCalendarArea";
-import DailyNutritionSummary from "./DailyNutritionSummary";
-import { BUCKET_TO_CATEGORY, Nutrition, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
-import type { Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
+import { CATEGORY_TO_BUCKET, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
+import type { Recipe, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
+import type { CalendarDragData } from "@/app/menuPlanning/page";
 
 interface DayViewProps {
   date: Date;
   refetchTrigger?: number;
 }
 
-type DayMeal = {
-  id: string;
-  name: string;
-  servingSize?: string;
-  tag: RecipeCategory;
-  category: RecipeBucket;
-};
-
 type CalendarDayResponse = {
   _id: string;
 } & RecipeBuckets<Recipe>;
+
+type DayMealCardProps = {
+  item: RecipeNutritionOnly;
+  dayId: string;
+  deletingId: string | null;
+  onDelete: (meal: RecipeNutritionOnly) => void;
+};
 
 const formatDayId = (date: Date) => {
   const year = date.getFullYear();
@@ -32,8 +32,111 @@ const formatDayId = (date: Date) => {
   return `${year}${month}${day}`;
 };
 
+export type DayMealCardPreviewProps = {
+  item: RecipeNutritionOnly;
+};
+
+export function DayMealCardPreview({ item }: DayMealCardPreviewProps) {
+  const tagClassName = TAG_STYLES[item.category];
+
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 shadow-lg">
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate font-montserrat text-xl font-bold" title={item.name}>
+          {item.name}
+        </h3>
+
+        {metaText ? <p className="font-montserrat text-base font-medium text-pepper/70">{metaText}</p> : null}
+      </div>
+
+      <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagClassName}`}>
+        {item.category}
+      </span>
+
+      <GripVertical className="h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
+    </div>
+  );
+}
+
+function DayMealCard({ item, dayId, deletingId, onDelete }: DayMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
+  const isDeleting = deletingId === item._id;
+
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
+
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useDraggable({
+    id: dndId,
+    data: dragData,
+    disabled: isDeleting,
+  });
+
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md ${
+        isDragging ? "opacity-40" : ""
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate font-montserrat text-xl font-bold" title={item.name}>
+          {item.name}
+        </h3>
+
+        {metaText ? <p className="font-montserrat text-base font-medium text-pepper/70">{metaText}</p> : null}
+      </div>
+
+      <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagClassName}`}>
+        {item.category}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => onDelete(item)}
+        disabled={isDeleting}
+        className="shrink-0 rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
+        aria-label={`Remove ${item.name}`}
+      >
+        <Trash2 size={18} strokeWidth={1.7} />
+      </button>
+
+      <button
+        // Only the vertical grip starts a drag, since otherwise the trashcan button would also drag
+        // Makes it easier to implement linking to the recipe on click later as well.
+        ref={setActivatorNodeRef}
+        type="button"
+        className="shrink-0 cursor-move rounded-md p-1.5 text-gray-500 transition hover:bg-gray-100"
+        aria-label={`Drag ${item.name}`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={20} strokeWidth={1.7} />
+      </button>
+    </div>
+  );
+}
+
 export default function DayView({ date, refetchTrigger }: DayViewProps) {
-  const [meals, setMeals] = useState<DayMeal[]>([]);
+  const [meals, setMeals] = useState<Recipe[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
@@ -55,19 +158,7 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
       }
 
       const calendarDay: CalendarDayResponse = await response.json();
-
-      const nextMeals = RECIPE_BUCKETS.flatMap((bucket) => {
-        const recipes = calendarDay[bucket] ?? [];
-        const tag = BUCKET_TO_CATEGORY[bucket];
-
-        return recipes.map((recipe) => ({
-          id: recipe._id,
-          name: recipe.name,
-          servingSize: recipe.serving != null ? `${recipe.serving} servings` : undefined,
-          tag,
-          category: bucket,
-        }));
-      });
+      const nextMeals = RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
 
       setMeals(nextMeals);
     } catch (error) {
@@ -82,16 +173,16 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
     fetchDayMeals();
   }, [fetchDayMeals, refetchTrigger]);
 
-  const handleDelete = async (meal: DayMeal) => {
-    setDeletingId(meal.id);
+  const handleDelete = async (meal: RecipeNutritionOnly) => {
+    setDeletingId(meal._id);
 
     try {
       const response = await fetch(`/api/calendar/${dayId}`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          recipeId: meal.id,
-          category: meal.category,
+          recipeId: meal._id,
+          category: CATEGORY_TO_BUCKET[meal.category],
         }),
       });
 
@@ -99,7 +190,7 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
         throw new Error("Failed to delete recipe from calendar");
       }
 
-      setMeals((prev) => prev.filter((m) => !(m.id === meal.id && m.category === meal.category)));
+      setMeals((prev) => prev.filter((m) => !(m._id === meal._id && m.category === meal.category)));
     } catch (error) {
       console.error("Error deleting recipe from calendar:", error);
     } finally {
@@ -107,57 +198,31 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
     }
   };
 
-  const emptyNutrition: Nutrition[] = [];
-
   return (
-    <div className="mt-4 flex flex-col gap-3">
-      <DroppableCalendarArea dayId={dayId}>
-        {isLoading ? (
-          <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 py-8 text-center font-montserrat text-xs font-medium text-pepper/55">
-            Loading meals...
-          </div>
-        ) : meals.length > 0 ? (
-          meals.map((meal) => {
-            const tagStyle = TAG_STYLES[meal.tag];
-
-            return (
-              <div
-                key={`${meal.id}-${meal.category}`}
-                className="flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md"
-              >
-                <div className="min-w-0 flex-1">
-                  <h3 className="truncate font-montserrat text-xl font-bold" title={meal.name}>
-                    {meal.name}
-                  </h3>
-
-                  {meal.servingSize ? (
-                    <p className="font-montserrat text-base font-medium text-pepper/70">{meal.servingSize}</p>
-                  ) : null}
-                </div>
-
-                <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagStyle}`}>
-                  {meal.tag}
-                </span>
-
-                <button
-                  onClick={() => handleDelete(meal)}
-                  disabled={deletingId === meal.id}
-                  className="shrink-0 rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
-                  aria-label={`Remove ${meal.name}`}
-                >
-                  <Trash2 size={18} strokeWidth={1.7} />
-                </button>
-              </div>
-            );
-          })
-        ) : (
-          <div className="flex flex-1 items-center justify-center py-8 text-center font-montserrat text-sm font-medium text-pepper/55">
-            Drop a recipe here to add it to today&apos;s menu
-          </div>
-        )}
-      </DroppableCalendarArea>
-
-      <DailyNutritionSummary recipes={emptyNutrition} />
+    <div className="flex flex-col gap-3 pt-4">
+      <div className="rounded-[14px] p-3 bg-white border border-medium-gray/35">
+        <DroppableCalendarArea dayId={dayId}>
+          {isLoading ? (
+            <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 py-8 text-center font-montserrat text-xs font-medium text-pepper/55">
+              Loading meals...
+            </div>
+          ) : meals.length > 0 ? (
+            meals.map((meal) => (
+              <DayMealCard
+                key={`${dayId}-${meal._id}`}
+                item={meal}
+                dayId={dayId}
+                deletingId={deletingId}
+                onDelete={handleDelete}
+              />
+            ))
+          ) : (
+            <div className="flex flex-1 items-center justify-center py-8 text-center font-montserrat text-sm font-medium text-pepper/55">
+              Drop a recipe here to add it to today&apos;s menu
+            </div>
+          )}
+        </DroppableCalendarArea>
+      </div>
     </div>
   );
 }

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -5,7 +5,7 @@ import { Trash2 } from "lucide-react";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 import DailyNutritionSummary from "./DailyNutritionSummary";
 import { BUCKET_TO_CATEGORY, Nutrition, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
-import type { RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
+import type { Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
 
 interface DayViewProps {
   date: Date;
@@ -20,15 +20,9 @@ type DayMeal = {
   category: RecipeBucket;
 };
 
-type CalendarRecipe = {
-  _id: string;
-  name: string;
-  serving?: number;
-};
-
 type CalendarDayResponse = {
   _id: string;
-} & Partial<RecipeBuckets<CalendarRecipe>>;
+} & RecipeBuckets<Recipe>;
 
 const formatDayId = (date: Date) => {
   const year = date.getFullYear();

--- a/src/components/menuPlanning/DraggableRecipeCard.tsx
+++ b/src/components/menuPlanning/DraggableRecipeCard.tsx
@@ -3,7 +3,8 @@
 import Image from "next/image";
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
-import { CATEGORY_TO_BUCKET, CategoryValue, Combo, Recipe, TAG_STYLES } from "@/lib/types";
+import { CategoryValue, Combo, Recipe, TAG_STYLES } from "@/lib/types";
+import type { SidebarDragData } from "@/app/menuPlanning/page";
 
 type DraggableRecipeCardProps = {
   item: Recipe | Combo;
@@ -25,34 +26,22 @@ export default function DraggableRecipeCard({ item, disabled = false }: Draggabl
   const servingText = item.serving != null ? `${item.serving}` : null;
   const metaText = caloriesText && servingText ? `${caloriesText} / ${servingText}` : caloriesText || servingText;
 
+  const dragData: SidebarDragData = itemIsRecipe
+    ? {
+        source: "sidebar",
+        itemType: "recipe",
+        item,
+      }
+    : {
+        source: "sidebar",
+        itemType: "combo",
+        item,
+      };
+
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `sidebar-${itemType}-${item._id}`,
     disabled,
-    data: itemIsRecipe
-      ? {
-          type: "recipe",
-          source: "sidebar",
-          itemType: "recipe",
-          recipeId: item._id,
-          name: item.name,
-          bucket: CATEGORY_TO_BUCKET[item.category],
-          category: item.category,
-          recipeCategory: item.category,
-          item,
-        }
-      : {
-          type: "recipe",
-          source: "sidebar",
-          itemType: "combo",
-          comboId: item._id,
-          name: item.name,
-          category: "Combo",
-          entrees: item.entrees,
-          vegetables: item.vegetables,
-          fruits: item.fruits,
-          grains: item.grains,
-          item,
-        },
+    data: dragData,
   });
 
   return (

--- a/src/components/menuPlanning/DroppableCalendarArea.tsx
+++ b/src/components/menuPlanning/DroppableCalendarArea.tsx
@@ -22,7 +22,7 @@ export default function DroppableCalendarArea({ dayId, children }: DroppableCale
   return (
     <div
       ref={setNodeRef}
-      className={`flex h-full min-h-55 w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
+      className={`flex h-full w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
         isOver ? "bg-radish-100 border-2 border-radish-900" : "border border-medium-gray/20 bg-white/30"
       }`}
     >

--- a/src/components/menuPlanning/DroppableCalendarArea.tsx
+++ b/src/components/menuPlanning/DroppableCalendarArea.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type { DropZoneData } from "@/app/menuPlanning/page";
 import { useDroppable } from "@dnd-kit/core";
 import { ReactNode } from "react";
 
@@ -9,12 +10,13 @@ interface DroppableCalendarAreaProps {
 }
 // TODO: figure out how this looks and if I can reuse it
 export default function DroppableCalendarArea({ dayId, children }: DroppableCalendarAreaProps) {
+  const dropData: DropZoneData = {
+    dest: "calendar",
+    dayId,
+  };
   const { setNodeRef, isOver } = useDroppable({
     id: `droppable-${dayId}`,
-    data: {
-      type: "calendar",
-      dayId,
-    },
+    data: dropData,
   });
 
   return (

--- a/src/components/menuPlanning/MonthMealCard.tsx
+++ b/src/components/menuPlanning/MonthMealCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
+import { CATEGORY_TO_BUCKET, TAG_STYLES } from "@/lib/types";
+import type { RecipeNutritionOnly } from "@/lib/types";
+import type { CalendarDragData } from "@/app/menuPlanning/page";
+
+type MonthMealCardProps = {
+  item: RecipeNutritionOnly;
+  dayId: string;
+};
+
+type MonthMealCardPreviewProps = {
+  item: RecipeNutritionOnly;
+};
+
+export function MonthMealCardPreview({ item }: MonthMealCardPreviewProps) {
+  const tagClassName = TAG_STYLES[item.category];
+
+  return (
+    <div
+      className={`flex w-40 max-w-40 items-center gap-1.5 rounded-md px-2 py-1 font-montserrat text-sm shadow-lg ${tagClassName}`}
+    >
+      <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
+        {item.name}
+      </p>
+
+      <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+    </div>
+  );
+}
+
+export default function MonthMealCard({ item, dayId }: MonthMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
+
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
+
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: dndId,
+    data: dragData,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex max-w-full cursor-move items-center gap-1.5 rounded-md px-2 py-1 font-montserrat text-sm shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
+        isDragging ? "opacity-40" : ""
+      }`}
+      {...attributes}
+      {...listeners}
+    >
+      <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
+        {item.name}
+      </p>
+
+      <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/components/menuPlanning/MonthView.tsx
+++ b/src/components/menuPlanning/MonthView.tsx
@@ -41,7 +41,7 @@ export default function MonthView({ monthDates, dateToday }: Props) {
           <div key={wi} className="grid min-h-0 flex-1 grid-cols-7 gap-2">
             {week.map((date, di) => {
               if (!date) {
-                return <div key={`${wi}-${di}`} className="min-h-[90px]" aria-hidden />;
+                return <div key={`${wi}-${di}`} className="min-h-22.5" aria-hidden />;
               }
               const weekend = isWeekend(date);
               const isToday = date.toDateString() === dateToday.toDateString();
@@ -50,7 +50,7 @@ export default function MonthView({ monthDates, dateToday }: Props) {
               return (
                 <div
                   key={`${wi}-${di}`}
-                  className={`relative min-h-[90px] overflow-hidden rounded-[12px] border border-medium-gray ${
+                  className={`relative min-h-22.5 overflow-hidden rounded-xl border border-medium-gray ${
                     weekend ? "bg-medium-gray/35" : "bg-white"
                   } ${isToday ? "ring-2 ring-radish-900" : ""} ${inMonth ? "" : "opacity-60"}`}
                   data-drop-disabled={weekend ? "true" : undefined}

--- a/src/components/menuPlanning/MonthView.tsx
+++ b/src/components/menuPlanning/MonthView.tsx
@@ -1,6 +1,19 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import DroppableCalendarArea from "./DroppableCalendarArea";
+import MonthMealCard from "./MonthMealCard";
+import { RECIPE_BUCKETS } from "@/lib/types";
+import type { CalendarDay, NutrientDisplay, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
+
 const WEEKDAY_LABELS = ["SUN", "MON", "TUE", "WED", "THUR", "FRI", "SAT"] as const;
+
+type Props = {
+  /** In-month dates only (1..last day). */
+  monthDates: Date[];
+  dateToday: Date;
+  refetchTrigger?: number;
+};
 
 function isWeekend(d: Date): boolean {
   const day = d.getDay();
@@ -11,23 +24,102 @@ function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
 
-type Props = {
-  /** In-month dates only (1..last day). */
-  monthDates: Date[];
-  dateToday: Date;
-};
+function formatCalendarDayId(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
 
-export default function MonthView({ monthDates, dateToday }: Props) {
+  return `${year}${month}${day}`;
+}
+
+function mapCalendarDayToMeals(calendarDay: CalendarDay<RecipeNutritionOnly>): RecipeNutritionOnly[] {
+  return RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
+}
+
+function getVisibleMonthMeals(meals: RecipeNutritionOnly[]) {
+  if (meals.length <= 2) {
+    return {
+      visibleMeals: meals,
+      hiddenCount: 0,
+    };
+  }
+
+  return {
+    visibleMeals: meals.slice(0, 1),
+    hiddenCount: meals.length - 1,
+  };
+}
+
+export default function MonthView({ monthDates, dateToday, refetchTrigger }: Props) {
+  const [mealsByDayId, setMealsByDayId] = useState<Record<string, RecipeNutritionOnly[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+
   const focusDate = monthDates[0] ?? new Date();
+  const year = focusDate.getFullYear();
+  const month = String(focusDate.getMonth() + 1).padStart(2, "0");
+
   const leadingBlanks = focusDate.getDay(); // Sunday-first
-  const cells: Array<Date | null> = [...Array.from({ length: leadingBlanks }, () => null), ...monthDates];
+
+  const cells: Array<Date | null> = useMemo(
+    () => [...Array.from({ length: leadingBlanks }, () => null), ...monthDates],
+    [leadingBlanks, monthDates],
+  );
+
   const weeks: Array<Array<Date | null>> = [];
+
   for (let i = 0; i < cells.length; i += 7) {
     weeks.push(cells.slice(i, i + 7));
   }
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchMonthMeals() {
+      setIsLoading(true);
+
+      try {
+        const response = await fetch(`/api/calendar?year=${year}&month=${month}&populate=nutrition`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch calendar month ${year}-${month}`);
+        }
+
+        const calendarDays: CalendarDay<RecipeNutritionOnly>[] = await response.json();
+
+        const nextMealsByDayId = calendarDays.reduce<Record<string, RecipeNutritionOnly[]>>((acc, calendarDay) => {
+          acc[calendarDay._id] = mapCalendarDayToMeals(calendarDay);
+          return acc;
+        }, {});
+
+        if (!controller.signal.aborted) {
+          setMealsByDayId(nextMealsByDayId);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+
+        console.error("Error fetching month meals:", error);
+
+        if (!controller.signal.aborted) {
+          setMealsByDayId({});
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchMonthMeals();
+
+    return () => controller.abort();
+  }, [year, month, refetchTrigger]);
+
   return (
-    <div className="mt-4 flex min-h-0 w-full flex-1 flex-col gap-2">
+    <div className="mt-4 flex w-full flex-col gap-2">
       <div className="grid shrink-0 grid-cols-7 gap-2">
         {WEEKDAY_LABELS.map((label) => (
           <div key={label} className="text-center font-montserrat text-xs font-medium uppercase text-dark-gray">
@@ -43,13 +135,37 @@ export default function MonthView({ monthDates, dateToday }: Props) {
               if (!date) {
                 return <div key={`${wi}-${di}`} className="min-h-22.5" aria-hidden />;
               }
+
+              const dayId = formatCalendarDayId(date);
               const weekend = isWeekend(date);
               const isToday = date.toDateString() === dateToday.toDateString();
               const inMonth = isSameMonth(date, focusDate);
+              const meals = mealsByDayId[dayId] ?? [];
+              const { visibleMeals, hiddenCount } = getVisibleMonthMeals(meals);
+
+              const cellContent = (
+                <div className="flex min-h-22.5 flex-col items-start gap-1 p-2 pt-5">
+                  {isLoading ? (
+                    <p className="font-montserrat text-sm text-pepper/45">Loading...</p>
+                  ) : visibleMeals.length > 0 ? (
+                    <>
+                      {visibleMeals.map((meal) => (
+                        <MonthMealCard key={`${dayId}-${meal._id}`} item={meal} dayId={dayId} />
+                      ))}
+
+                      {hiddenCount > 0 ? (
+                        <div className="flex h-6 min-w-6 items-center justify-center rounded-md bg-jicama px-1.5 font-montserrat text-sm">
+                          +{hiddenCount}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : null}
+                </div>
+              );
 
               return (
                 <div
-                  key={`${wi}-${di}`}
+                  key={dayId}
                   className={`relative min-h-22.5 overflow-hidden rounded-xl border border-medium-gray ${
                     weekend ? "bg-medium-gray/35" : "bg-white"
                   } ${isToday ? "ring-2 ring-radish-900" : ""} ${inMonth ? "" : "opacity-60"}`}
@@ -57,9 +173,11 @@ export default function MonthView({ monthDates, dateToday }: Props) {
                   aria-disabled={weekend}
                   title={weekend ? "Weekends — meals cannot be placed here" : undefined}
                 >
-                  <span className="absolute right-2 top-2 font-montserrat text-sm font-normal text-dark-gray">
+                  <span className="absolute top-2 right-2 z-10 font-montserrat text-sm font-normal text-dark-gray">
                     {String(date.getDate()).padStart(2, "0")}
                   </span>
+
+                  {weekend ? cellContent : <DroppableCalendarArea dayId={dayId}>{cellContent}</DroppableCalendarArea>}
                 </div>
               );
             })}

--- a/src/components/menuPlanning/RecipeDatabase.tsx
+++ b/src/components/menuPlanning/RecipeDatabase.tsx
@@ -44,7 +44,7 @@ export default function RecipeDatabase({
   onPageChange,
 }: RecipeDatabaseProps) {
   return (
-    <div className="h-full p-6">
+    <div className="flex flex-col p-6 overflow-auto">
       <div className="mb-6 text-xl font-semibold">Recipe Database</div>
 
       <div className="flex flex-row items-center gap-4">
@@ -94,12 +94,11 @@ export default function RecipeDatabase({
       {loading && <div>Loading...</div>}
       {error && <div>{error}</div>}
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col min-h-0 gap-4 overflow-auto">
         {items.map((item) => (
           <DraggableRecipeCard key={item._id} item={item} />
         ))}
       </div>
-
       <div className="mt-4 flex justify-center">
         <PaginationDisplay
           currentPage={currentPage}

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -2,50 +2,35 @@
 
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
-import { RecipeBucket, RecipeCategory, TAG_STYLES } from "@/lib/types";
+import { CATEGORY_TO_BUCKET, TAG_STYLES, type Recipe, type RecipeBucket, type RecipeCategory } from "@/lib/types";
+import { ActiveDragData, CalendarDragData } from "@/app/menuPlanning/page";
 
-export type WeekMealCardData = {
-  _id: string;
-  name: string;
-  calories?: number;
-  servingSize?: string;
-  category: RecipeCategory;
-  calendarDayId: string;
-  calendarBucket: RecipeBucket;
+export type WeekMealCardProps = {
+  item: Recipe;
+  dayId: string;
 };
 
-type WeekMealCardProps = WeekMealCardData;
+export default function WeekMealCard({ item, dayId }: WeekMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
 
-export default function WeekMealCard({
-  _id,
-  name,
-  calories,
-  servingSize,
-  category,
-  calendarDayId,
-  calendarBucket,
-}: WeekMealCardProps) {
-  const dndId = `calendar-${calendarDayId}-${calendarBucket}-${_id}`;
-  const tagClassName = TAG_STYLES[category];
-
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: dndId,
-    data: {
-      type: "recipe",
-      source: "calendar",
-      itemType: "recipe",
-      recipeId: _id,
-      dayId: calendarDayId,
-      bucket: calendarBucket,
-      category,
-      recipeCategory: category,
-      name,
-      servingSize,
-    },
+    data: dragData,
   });
 
-  const caloriesText = calories != null ? `${calories} cal` : null;
-  const metaText = caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || servingSize;
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
 
   return (
     <div
@@ -57,8 +42,8 @@ export default function WeekMealCard({
       {...listeners}
     >
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[16px] leading-tight font-bold" title={name}>
-          {name}
+        <p className="truncate text-[16px] leading-tight font-bold" title={item.name}>
+          {item.name}
         </p>
 
         {metaText ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{metaText}</p> : null}

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -17,7 +17,6 @@ type WeekViewDayData = {
   showNutritionInfoNotMet?: boolean;
 };
 
-// TODO: extract this into a populated type in types.ts and add API support
 type CalendarRecipe = Pick<Recipe, "_id" | "name" | "serving"> & {
   nutritional_info?: Partial<Recipe["nutritional_info"]>;
 };

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import WeekMealCard, { type WeekMealCardData } from "./WeekMealCard";
+import WeekMealCard from "./WeekMealCard";
 import NutritionInfoNotMetCard from "./NutritionInfoNotMetCard";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 import { BUCKET_TO_CATEGORY, RECIPE_BUCKETS, Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
@@ -13,17 +13,13 @@ interface WeekViewProps {
 }
 
 type WeekViewDayData = {
-  meals: WeekMealCardData[];
+  meals: Recipe[];
   showNutritionInfoNotMet?: boolean;
-};
-
-type CalendarRecipe = Pick<Recipe, "_id" | "name" | "serving"> & {
-  nutritional_info?: Partial<Recipe["nutritional_info"]>;
 };
 
 type CalendarDayResponse = {
   _id: string;
-} & RecipeBuckets<CalendarRecipe>;
+} & RecipeBuckets<Recipe>;
 
 const EMPTY_DAY: WeekViewDayData = {
   meals: [],
@@ -38,29 +34,8 @@ function formatCalendarDayId(date: Date) {
   return `${year}${month}${day}`;
 }
 
-function mapCalendarRecipesToMeals(
-  recipes: CalendarRecipe[],
-  category: RecipeCategory,
-  calendarBucket: RecipeBucket,
-  calendarDayId: string,
-): WeekMealCardData[] {
-  return recipes.map((recipe) => ({
-    _id: recipe._id,
-    name: recipe.name,
-    calories: recipe.nutritional_info?.calories,
-    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined,
-    category,
-    calendarBucket,
-    calendarDayId,
-  }));
-}
-
-function mapCalendarDayToMeals(calendarDay: CalendarDayResponse, fallbackDayId: string): WeekMealCardData[] {
-  const calendarDayId = calendarDay._id || fallbackDayId;
-
-  return RECIPE_BUCKETS.flatMap((bucket) =>
-    mapCalendarRecipesToMeals(calendarDay[bucket] ?? [], BUCKET_TO_CATEGORY[bucket], bucket, calendarDayId),
-  );
+function mapCalendarDayToMeals(calendarDay: CalendarDayResponse): Recipe[] {
+  return RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
 }
 
 async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promise<WeekViewDayData> {
@@ -80,7 +55,7 @@ async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promis
   const calendarDay: CalendarDayResponse = await response.json();
 
   return {
-    meals: mapCalendarDayToMeals(calendarDay, dayId),
+    meals: mapCalendarDayToMeals(calendarDay),
     showNutritionInfoNotMet: false,
   };
 }
@@ -155,9 +130,7 @@ export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekV
                     Loading meals...
                   </div>
                 ) : dayData.meals.length > 0 ? (
-                  dayData.meals.map((meal) => (
-                    <WeekMealCard key={`${meal.calendarDayId}-${meal.calendarBucket}-${meal._id}`} {...meal} />
-                  ))
+                  dayData.meals.map((meal) => <WeekMealCard key={`${dayId}-${meal._id}`} item={meal} dayId={dayId} />)
                 ) : (
                   <div className="flex flex-1 items-center justify-center text-center font-montserrat text-xs font-medium text-pepper/55">
                     Drop recipe here

--- a/src/database/ComboSchema.ts
+++ b/src/database/ComboSchema.ts
@@ -1,3 +1,4 @@
+import { PROTEIN_SOURCES } from "@/lib/types";
 import mongoose, { Schema } from "mongoose";
 
 const ComboSchema = new Schema(
@@ -34,16 +35,29 @@ const ComboSchema = new Schema(
       default: [],
     },
 
-    filters: {
-      type: [String],
-      required: true,
+    proteinSources: {
+      type: [
+        {
+          type: String,
+          enum: PROTEIN_SOURCES,
+        },
+      ],
       default: [],
     },
 
-    allergens: {
-      type: [String],
-      required: true,
-      default: [],
+    dietary: {
+      vegetarian: { type: Boolean, default: false },
+      vegan: { type: Boolean, default: false },
+      halal: { type: Boolean, default: false },
+      kosher: { type: Boolean, default: false },
+    },
+
+    exclusions: {
+      dairyFree: { type: Boolean, default: false },
+      glutenFree: { type: Boolean, default: false },
+      nutFree: { type: Boolean, default: false },
+      soyFree: { type: Boolean, default: false },
+      shellfishFree: { type: Boolean, default: false },
     },
 
     notes: { type: String, required: false },

--- a/src/database/RecipeSchema.ts
+++ b/src/database/RecipeSchema.ts
@@ -1,7 +1,7 @@
 import mongoose, { Schema } from "mongoose";
 import Ingredient from "./IngredientSchema";
 import Nutrition from "./NutritionSchema";
-import { RECIPE_CATEGORIES } from "@/lib/types";
+import { PROTEIN_SOURCES, RECIPE_CATEGORIES } from "@/lib/types";
 
 const RecipeSchema = new Schema(
   {
@@ -25,8 +25,30 @@ const RecipeSchema = new Schema(
       required: true,
     },
 
-    allergens: { type: [String], required: true },
-    filters: { type: [String], required: true },
+    proteinSources: {
+      type: [
+        {
+          type: String,
+          enum: PROTEIN_SOURCES,
+        },
+      ],
+      default: [],
+    },
+
+    dietary: {
+      vegetarian: { type: Boolean, default: false },
+      vegan: { type: Boolean, default: false },
+      halal: { type: Boolean, default: false },
+      kosher: { type: Boolean, default: false },
+    },
+
+    exclusions: {
+      dairyFree: { type: Boolean, default: false },
+      glutenFree: { type: Boolean, default: false },
+      nutFree: { type: Boolean, default: false },
+      soyFree: { type: Boolean, default: false },
+      shellfishFree: { type: Boolean, default: false },
+    },
 
     ingredients: {
       type: [Ingredient.schema],

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -7,6 +7,7 @@ type Params = {
   selectedCategories: Set<CategoryValue>;
   draftMode: boolean;
   sortBy?: SortOption;
+  pageSize?: number;
 };
 
 type Return = {
@@ -21,7 +22,6 @@ type Return = {
   refresh: () => void;
 };
 
-const PAGE_SIZE = 5;
 function appendSetParams(params: URLSearchParams, key: string, values?: Set<unknown>) {
   values?.forEach((value) => {
     params.append(key, String(value));
@@ -34,6 +34,7 @@ export function useMealData({
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
+  pageSize = 11,
 }: Params): Return {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [recipes, setRecipes] = useState<Recipe[]>([]);
@@ -75,7 +76,7 @@ export function useMealData({
         params.append("isDraft", draftMode ? "true" : "false");
         params.append("sortBy", sortBy);
         params.append("page", String(currentPage));
-        params.append("limit", String(draftMode ? PAGE_SIZE - 1 : PAGE_SIZE));
+        params.append("limit", String(draftMode ? pageSize - 1 : pageSize));
 
         if (trimmed) {
           params.append("name", trimmed);
@@ -163,6 +164,7 @@ export function useMealData({
     sortBy,
     refreshKey,
     isSubrecipeOnly,
+    pageSize,
   ]);
 
   const items = isComboMode ? combos : recipes;

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { CategoryValue, Combo, FilterSelections, Recipe, SortOption } from "@/lib/types";
 
+type ComboPopulate = "all" | "preview" | "nutrition" | "filters";
+
 type Params = {
   search: string;
   filters: FilterSelections;
@@ -8,10 +10,11 @@ type Params = {
   draftMode: boolean;
   sortBy?: SortOption;
   pageSize?: number;
+  comboPopulate?: ComboPopulate;
 };
 
-type Return = {
-  items: Recipe[] | Combo[];
+type Return<TComboRecipe = string> = {
+  items: Recipe[] | Combo<TComboRecipe>[]; // This hook can optionally populate the combos with the recipe data.
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
@@ -28,17 +31,18 @@ function appendSetParams(params: URLSearchParams, key: string, values?: Set<unkn
   });
 }
 
-export function useMealData({
+export function useMealData<TComboRecipe = string>({
   search,
   filters,
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
   pageSize = 11,
-}: Params): Return {
+  comboPopulate,
+}: Params): Return<TComboRecipe> {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [combos, setCombos] = useState<Combo[]>([]);
+  const [combos, setCombos] = useState<Combo<TComboRecipe>[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [draftCount, setDraftCount] = useState(0);
@@ -86,6 +90,11 @@ export function useMealData({
         appendSetParams(params, "dietary", filters.dietary);
         appendSetParams(params, "exclusions", filters.exclusions);
         appendSetParams(params, "servings", filters.servings);
+
+        // Combo-only population parameter
+        if (isComboMode && comboPopulate) {
+          params.append("populate", comboPopulate);
+        }
 
         // Recipe-only filter.
         if (!isComboMode && isSubrecipeOnly) {
@@ -165,6 +174,7 @@ export function useMealData({
     refreshKey,
     isSubrecipeOnly,
     pageSize,
+    comboPopulate,
   ]);
 
   const items = isComboMode ? combos : recipes;

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { buildFilterTags } from "@/lib/helpers";
 import { CategoryValue, Combo, FilterSelections, Recipe, SortOption } from "@/lib/types";
 
 type Params = {
@@ -23,6 +22,11 @@ type Return = {
 };
 
 const PAGE_SIZE = 5;
+function appendSetParams(params: URLSearchParams, key: string, values?: Set<unknown>) {
+  values?.forEach((value) => {
+    params.append(key, String(value));
+  });
+}
 
 export function useMealData({
   search,
@@ -45,9 +49,6 @@ export function useMealData({
 
   const isComboMode = selectedCategories.has("Combo");
   const isSubrecipeOnly = filters.additional?.has("isSubrecipe") ?? false;
-
-  // TODO: This is a hopefully temporary hack, new filter schema will support this better.
-  const SPECIAL_FILTERS = new Set(["issubrecipe"]);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 250);
@@ -73,44 +74,35 @@ export function useMealData({
 
         params.append("isDraft", draftMode ? "true" : "false");
         params.append("sortBy", sortBy);
+        params.append("page", String(currentPage));
+        params.append("limit", String(draftMode ? PAGE_SIZE - 1 : PAGE_SIZE));
 
-        // If the parameter is present, then filter. Otherwise get any.
-        // Has no effect on combos.
+        if (trimmed) {
+          params.append("name", trimmed);
+        }
+
+        appendSetParams(params, "proteinSources", filters.proteinSources);
+        appendSetParams(params, "dietary", filters.dietary);
+        appendSetParams(params, "exclusions", filters.exclusions);
+        appendSetParams(params, "servings", filters.servings);
+
+        // Recipe-only filter.
         if (!isComboMode && isSubrecipeOnly) {
           params.append("isSubrecipe", "true");
         }
 
-        if (trimmed) {
-          params.append("name", trimmed);
-        } else {
-          // isSubrecipe should not be a part of the "tags", since it is its own field.
-          const tagParams = buildFilterTags(filters).filter((tag) => !SPECIAL_FILTERS.has(tag));
-          console.log(tagParams);
-          tagParams.forEach((t) => {
-            if (t.includes("serving")) {
-              params.append("servings", t);
-            } else {
-              params.append("filters", t);
-              params.append("allergens", t);
-            }
+        // Recipe-only categories.
+        if (!isComboMode) {
+          const categoryParams = Array.from(selectedCategories).filter((category) => category !== "Combo");
+
+          categoryParams.forEach((category) => {
+            params.append("categories", category);
           });
         }
 
-        if (!isComboMode) {
-          const categoryParams = Array.from(selectedCategories).filter((category) => category !== "Combo");
-          categoryParams.forEach((category) => params.append("categories", category));
-        }
-
-        const url = `${base}?${params.toString()}`;
-
-        // if in draft view, change PAGE_SIZE to PAGE_SIZE - 1
-        let paginatedUrl;
-        if (draftMode) {
-          paginatedUrl = `${url}&page=${currentPage}&limit=${PAGE_SIZE - 1}`;
-        } else {
-          paginatedUrl = `${url}&page=${currentPage}&limit=${PAGE_SIZE}`;
-        }
-        const res = await fetch(paginatedUrl, { signal: controller.signal });
+        const res = await fetch(`${base}?${params.toString()}`, {
+          signal: controller.signal,
+        });
 
         if (!res.ok) {
           throw new Error(`Request failed: ${res.status}`);
@@ -118,6 +110,7 @@ export function useMealData({
 
         const { data, totalCount, totalPages: serverTotalPages } = await res.json();
         const safeTotalPages = Math.max(1, Number(serverTotalPages) || 0);
+
         setTotalPages(safeTotalPages);
 
         if (currentPage > safeTotalPages) {
@@ -136,8 +129,11 @@ export function useMealData({
         } else {
           const draftParams = new URLSearchParams();
           draftParams.append("isDraft", "true");
-          const draftUrl = `${base}?${draftParams.toString()}&limit=1`;
-          const draftRes = await fetch(draftUrl, { signal: controller.signal });
+          draftParams.append("limit", "1");
+
+          const draftRes = await fetch(`${base}?${draftParams.toString()}`, {
+            signal: controller.signal,
+          });
 
           if (!draftRes.ok) {
             throw new Error(`Request failed: ${draftRes.status}`);
@@ -155,6 +151,7 @@ export function useMealData({
     }
 
     load();
+
     return () => controller.abort();
   }, [
     currentPage,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -39,3 +39,13 @@ export function toggleCategory(
     return next;
   });
 }
+
+export function cloneFilterSelections(f: FilterSelections): FilterSelections {
+  return {
+    proteinSources: new Set(f.proteinSources),
+    dietary: new Set(f.dietary),
+    exclusions: new Set(f.exclusions),
+    servings: new Set(f.servings),
+    additional: new Set(f.additional),
+  };
+}

--- a/src/lib/server/comboHelpers.ts
+++ b/src/lib/server/comboHelpers.ts
@@ -1,0 +1,196 @@
+import "server-only";
+
+import Recipe from "@/database/RecipeSchema";
+import Combo from "@/database/ComboSchema";
+import { DIETARY_KEYS, EMPTY_DIETARY_FLAGS, EMPTY_EXCLUSION_FLAGS, EXCLUSION_KEYS, RECIPE_BUCKETS } from "@/lib/types";
+import type {
+  DietaryFlags,
+  DietaryKey,
+  ExclusionFlags,
+  ExclusionKey,
+  MealFilterFields,
+  ProteinSource,
+  RecipeBucket,
+  RecipeBuckets,
+} from "@/lib/types";
+
+type RecipeFilterFields = {
+  _id: string;
+  proteinSources?: ProteinSource[];
+  dietary?: Partial<Record<DietaryKey, boolean>>;
+  exclusions?: Partial<Record<ExclusionKey, boolean>>;
+};
+
+function unique<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+export async function deriveComboDataFromRecipeIds(recipeBuckets: RecipeBuckets): Promise<MealFilterFields> {
+  // Used to aggregate the filters from all recipes in a combo
+  // into one single filters object for the combo itself.
+  // TODO: Nutritional information could be updated here as well.
+  const recipeIds = unique(RECIPE_BUCKETS.flatMap((bucket) => recipeBuckets[bucket] ?? []));
+
+  if (recipeIds.length === 0) {
+    return {
+      proteinSources: [],
+      dietary: { ...EMPTY_DIETARY_FLAGS },
+      exclusions: { ...EMPTY_EXCLUSION_FLAGS },
+    };
+  }
+
+  const recipes = await Recipe.find({ _id: { $in: recipeIds } })
+    .select("_id proteinSources dietary exclusions")
+    .lean<RecipeFilterFields[]>();
+
+  if (recipes.length !== recipeIds.length) {
+    // If stale recipes become a problem, could choose to remove
+    // recipes that could not be found.
+    throw new Error("One or more recipes in this combo could not be found.");
+  }
+
+  // Adds a protein type if ANY recipes have that protein type
+  const proteinSources = unique(recipes.flatMap((recipe) => recipe.proteinSources ?? []));
+
+  // Adds a dietary restriction if ALL recipes have that restriction
+  const dietary = DIETARY_KEYS.reduce(
+    (result, key) => {
+      result[key] = recipes.every((recipe) => recipe.dietary?.[key] === true);
+      return result;
+    },
+    { ...EMPTY_DIETARY_FLAGS } as DietaryFlags,
+  );
+
+  // Adds an exclusion if ALL recipes have that exclusion
+  const exclusions = EXCLUSION_KEYS.reduce(
+    (result, key) => {
+      result[key] = recipes.every((recipe) => recipe.exclusions?.[key] === true);
+      return result;
+    },
+    { ...EMPTY_EXCLUSION_FLAGS } as ExclusionFlags,
+  );
+
+  return {
+    proteinSources,
+    dietary,
+    exclusions,
+  };
+}
+
+function getUpdatedRecipeBucket(
+  updates: Record<string, unknown>,
+  existingCombo: RecipeBuckets,
+  bucket: RecipeBucket,
+): string[] {
+  // If this bucket (entrees, vegetables, etc) was updated, then use the updated version
+  // if not, then use the version from the existing combo
+  if (!(bucket in updates)) {
+    return existingCombo[bucket] ?? [];
+  }
+
+  const value = updates[bucket];
+
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`Invalid ${bucket} value`);
+  }
+
+  return value;
+}
+
+export function getFinalRecipeBuckets(updates: Record<string, unknown>, existingCombo: RecipeBuckets): RecipeBuckets {
+  // When a combo is updated, we need to recalculate filters based on ALL the recipes in the combo.
+  // This function will find all the recipes, which then can be fed into the accumulator helper.
+  return {
+    entrees: getUpdatedRecipeBucket(updates, existingCombo, "entrees"),
+    vegetables: getUpdatedRecipeBucket(updates, existingCombo, "vegetables"),
+    fruits: getUpdatedRecipeBucket(updates, existingCombo, "fruits"),
+    grains: getUpdatedRecipeBucket(updates, existingCombo, "grains"),
+  };
+}
+
+export function getRecipeBucketsFromBody(body: Record<string, unknown>): RecipeBuckets {
+  const buckets = {} as RecipeBuckets;
+
+  for (const bucket of RECIPE_BUCKETS) {
+    const value = body[bucket];
+
+    if (value == null) {
+      buckets[bucket] = [];
+      continue;
+    }
+
+    if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+      throw new Error(`Invalid ${bucket} value`);
+    }
+
+    buckets[bucket] = value;
+  }
+
+  return buckets;
+}
+
+type ComboRecipeBuckets = {
+  _id: string;
+} & RecipeBuckets;
+
+function getRecipeBucketsFromCombo(combo: ComboRecipeBuckets): RecipeBuckets {
+  return {
+    entrees: combo.entrees ?? [],
+    vegetables: combo.vegetables ?? [],
+    fruits: combo.fruits ?? [],
+    grains: combo.grains ?? [],
+  };
+}
+
+export async function refreshCombosContainingRecipe(recipeId: string) {
+  // Query for every combo containing this recipe in any bucket (entrees, Vegetables, etc)
+  // Then, update the derived data for the combo.
+  // TODO: Nutrition data can be updated here as well.
+  const combos = await Combo.find({
+    $or: RECIPE_BUCKETS.map((bucket) => ({
+      [bucket]: recipeId,
+    })),
+  })
+    .select("_id entrees vegetables fruits grains")
+    .lean<ComboRecipeBuckets[]>();
+
+  if (combos.length === 0) {
+    return {
+      matchedCount: 0,
+      modifiedCount: 0,
+    };
+  }
+
+  await Promise.all(
+    combos.map(async (combo) => {
+      const recipeBuckets = getRecipeBucketsFromCombo(combo);
+      const calculatedFilters = await deriveComboDataFromRecipeIds(recipeBuckets);
+
+      await Combo.findByIdAndUpdate(
+        combo._id,
+        {
+          $set: calculatedFilters,
+        },
+        {
+          runValidators: true,
+        },
+      );
+    }),
+  );
+
+  return {
+    matchedCount: combos.length,
+    modifiedCount: combos.length,
+  };
+}
+
+export function updateAffectsComboData(updates: Record<string, unknown>) {
+  return Object.keys(updates).some(
+    (key) =>
+      key === "proteinSources" ||
+      key === "dietary" ||
+      key === "exclusions" ||
+      key.startsWith("dietary.") ||
+      key.startsWith("exclusions."),
+  );
+}

--- a/src/lib/server/searchParams.ts
+++ b/src/lib/server/searchParams.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+export function normalizeAllowedValue<T extends string>(value: string, allowedValues: readonly T[]): T | null {
+  const normalizedValue = value.trim().toLowerCase();
+
+  return allowedValues.find((allowedValue) => allowedValue.toLowerCase() === normalizedValue) ?? null;
+}
+// Used so that queries are a little more forgiving.
+// Can normalize whitespace and capitalization to a list of allowed values.
+
+export function getNormalizedParams<T extends string>(
+  searchParams: URLSearchParams,
+  key: string,
+  allowedValues: readonly T[],
+): T[] {
+  return searchParams
+    .getAll(key)
+    .map((value) => normalizeAllowedValue(value, allowedValues))
+    .filter((value): value is T => Boolean(value));
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,6 +125,9 @@ export type RecipeMinimal = {
   name: string;
 };
 
+export type RecipeNutritionOnly = RecipePreview & { serving: number; nutritional_info: Nutrition };
+export type RecipeFiltersOnly = RecipePreview & MealFilterFields;
+
 // Takes the type of the recipe buckets.
 // By default should be string IDs, but can request Recipe or RecipePreviews from the API as well.
 // TODO: add a "populate" parameter to the combo schema that will also preview the recipes
@@ -146,9 +149,9 @@ export type Combo<T = string> = {
 /* Calendar and date types                                                    */
 /* -------------------------------------------------------------------------- */
 
-export type CalendarDay = {
+export type CalendarDay<T = Recipe> = {
   _id: string; // YYYYMMDD
-} & RecipeBuckets<Recipe>;
+} & RecipeBuckets<T>;
 
 export const MONTHS = [
   "January",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,7 +83,7 @@ export const BUCKET_TO_CATEGORY = {
   grains: "Grain",
 } as const satisfies Record<RecipeBucket, RecipeCategory>;
 
-export type RecipeBuckets<T> = {
+export type RecipeBuckets<T = string> = {
   // Can be parametrized as strings (for _id), full recipes, or previews.
   entrees: T[];
   vegetables: T[];
@@ -103,9 +103,6 @@ export type Recipe = {
   category: RecipeCategory;
   isSubrecipe: boolean;
 
-  filters: string[];
-  allergens: string[];
-
   ingredients: Ingredient[];
   instructions?: string;
   notes?: string;
@@ -115,36 +112,35 @@ export type Recipe = {
 
   isDraft: boolean;
   nutritional_info: Nutrition;
-};
+} & MealFilterFields;
 
 export type RecipePreview = {
   _id: string;
   name: string;
+  category: RecipeCategory;
 };
 
-export type Combo = {
+export type RecipeMinimal = {
+  _id: string;
+  name: string;
+};
+
+// Takes the type of the recipe buckets.
+// By default should be string IDs, but can request Recipe or RecipePreviews from the API as well.
+// TODO: add a "populate" parameter to the combo schema that will also preview the recipes
+// This would cut the fetches required for the recipes page by 90%.
+export type Combo<T = string> = {
   _id: string;
   name: string;
   serving: number;
-
-  filters: string[];
-  allergens: string[];
 
   notes?: string;
   instructions?: string;
   imageUrl?: string;
 
   isDraft: boolean;
-} & RecipeBuckets<string>;
-
-// TODO: add a "populate" parameter to the combo schema that will also preview the recipes
-// This cuts the fetches required for the recipes page by 90%.
-// export type PopulatedCombo = Omit<Combo, "entrees" | "vegetables" | "fruits" | "grains"> & {
-//   entrees: RecipePreview[];
-//   vegetables: RecipePreview[];
-//   fruits: RecipePreview[];
-//   grains: RecipePreview[];
-// };
+} & MealFilterFields &
+  RecipeBuckets<T>;
 
 /* -------------------------------------------------------------------------- */
 /* Calendar and date types                                                    */
@@ -174,15 +170,125 @@ export type Month = (typeof MONTHS)[number];
 /* Filtering                                                                  */
 /* -------------------------------------------------------------------------- */
 
-export type FilterSelections = Record<string, Set<string>>;
+export const PROTEIN_SOURCES = ["Chicken", "Beef", "Fish", "Tofu", "Beans"] as const;
+export type ProteinSource = (typeof PROTEIN_SOURCES)[number];
 
-export const EMPTY_FILTERS: FilterSelections = {
-  allergens: new Set(),
-  proteins: new Set(),
-  vitamins: new Set(),
-  dietary: new Set(),
-  serving: new Set(),
+export const DIETARY_KEYS = ["vegetarian", "vegan", "halal", "kosher"] as const;
+export type DietaryKey = (typeof DIETARY_KEYS)[number];
+
+export const EXCLUSION_KEYS = ["dairyFree", "glutenFree", "nutFree", "soyFree", "shellfishFree"] as const;
+export type ExclusionKey = (typeof EXCLUSION_KEYS)[number];
+
+export const SERVING_FILTER_KEYS = ["single-serving", "small-serving", "family-serving", "party-serving"] as const;
+export type ServingFilterKey = (typeof SERVING_FILTER_KEYS)[number];
+
+export const ADDITIONAL_FILTER_KEYS = ["isSubrecipe"] as const;
+export type AdditionalFilterKey = (typeof ADDITIONAL_FILTER_KEYS)[number];
+
+export type DietaryFlags = Record<DietaryKey, boolean>;
+export type ExclusionFlags = Record<ExclusionKey, boolean>;
+
+export type MealFilterFields = {
+  proteinSources: ProteinSource[];
+  dietary: DietaryFlags;
+  exclusions: ExclusionFlags;
 };
+
+export type FilterOptionId = ExclusionKey | DietaryKey | ProteinSource | ServingFilterKey | AdditionalFilterKey;
+export type FilterSelections = {
+  proteinSources: Set<FilterOptionId>;
+  dietary: Set<FilterOptionId>;
+  exclusions: Set<FilterOptionId>;
+  servings: Set<FilterOptionId>;
+  additional: Set<FilterOptionId>;
+};
+export type FilterSectionId = keyof FilterSelections;
+
+export type FilterOption = {
+  id: FilterOptionId;
+  label: string;
+};
+
+export type FilterSection = {
+  id: FilterSectionId;
+  label: string;
+  options: FilterOption[];
+};
+
+export const EMPTY_DIETARY_FLAGS: DietaryFlags = {
+  vegetarian: false,
+  vegan: false,
+  halal: false,
+  kosher: false,
+};
+
+export const EMPTY_EXCLUSION_FLAGS: ExclusionFlags = {
+  dairyFree: false,
+  glutenFree: false,
+  nutFree: false,
+  soyFree: false,
+  shellfishFree: false,
+};
+
+export function createEmptyFilterSelections(): FilterSelections {
+  return {
+    proteinSources: new Set(),
+    dietary: new Set(),
+    exclusions: new Set(),
+    servings: new Set(),
+    additional: new Set(),
+  };
+}
+
+export const FILTER_SECTIONS: FilterSection[] = [
+  {
+    id: "exclusions",
+    label: "Allergens / Exclusions",
+    options: [
+      { id: "dairyFree", label: "Dairy-Free" },
+      { id: "glutenFree", label: "Gluten-Free" },
+      { id: "nutFree", label: "Nut-Free" },
+      { id: "soyFree", label: "Soy-Free" },
+      { id: "shellfishFree", label: "Shellfish-Free" },
+    ],
+  },
+  {
+    id: "proteinSources",
+    label: "Proteins",
+    options: [
+      { id: "Chicken", label: "Chicken" },
+      { id: "Beef", label: "Beef" },
+      { id: "Fish", label: "Fish" },
+      { id: "Tofu", label: "Tofu" },
+      { id: "Beans", label: "Beans" },
+    ],
+  },
+  {
+    id: "dietary",
+    label: "Dietary Preferences",
+    options: [
+      { id: "vegetarian", label: "Vegetarian" },
+      { id: "vegan", label: "Vegan" },
+      { id: "halal", label: "Halal" },
+      { id: "kosher", label: "Kosher" },
+    ],
+  },
+  {
+    id: "servings",
+    label: "Serving Size",
+    options: [
+      { id: "single-serving", label: "Single Serving" },
+      { id: "small-serving", label: "Small Serving" },
+      { id: "family-serving", label: "Family Serving" },
+      { id: "party-serving", label: "Party Serving" },
+    ],
+  },
+  {
+    id: "additional",
+    label: "Additional Filters",
+    options: [{ id: "isSubrecipe", label: "Subrecipes Only" }],
+  },
+];
 
 /* -------------------------------------------------------------------------- */
 /* Sorting                                                                    */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -315,7 +315,6 @@ export const TAG_STYLES = {
   Grain: "bg-grain-bg text-grain-text",
 } satisfies Record<CategoryValue, string>;
 
-// TODO: pages that use icons should pull from here, so updating happens across all pages.
 export type CategoryDisplayType = { category: CategoryValue; label: string; plural: string; icon: LucideIcon };
 
 export const COMBO_ICON = Utensils;


### PR DESCRIPTION
## Developer: Kevin Diaz

Closes #165 

### Pull Request Summary

Changes the Filter schema on recipes and combos to have more structure.
On combo creation and update, they will derive the filters from the recipes.
On recipe update, any combos that use the recipe will be refreshed.
Front end supports querying and displaying the new filters.

NOTE: The vitamin/mineral filters were lost in the update. They were based on manually inputting a tag for each, and not on the actual nutritional content. If needed I can add them back (should not be a big deal), but the issue did not mention them. Also, maybe it would be better to add based on the new nutritional schema later.

### Modifications

- `src/app/api/combos/[id]/route.ts`: When a combo is updated it will recalculate its filters. This logic can be extended to calculate nutritional information as well.
- `src/app/api/combos/route.ts`
  - Uses the new filters schema for filtering and searching
  - When a new combo is created it will derive its filters from the recipes
- src/app/api/recipes/[id]/route.ts: When a recipe is updated it will refresh any combos that it is a part of. This can be extended to refresh nutritional information as well.
- `src/app/api/recipes/route.ts`: Uses the new filters for search. Fixes a bug that made filtering and searching by name mutually exclusive.
- `src/app/drafts/page.tsx`: update types.
- `src/app/menuPlanning/page.tsx`:
  - update types
  - Added some comments about some cleanup I would like to do
- `src/app/recipe/page.tsx`: remove unused imports
- `src/components/createRecipe/DropdownField.tsx`, `src/components/createRecipe/FieldRow.tsx`, `src/components/createRecipe/NutritionalInfo.tsx`: pulled out a component from CreateRecipePopUp, since the file was way too long.
- `src/components/FilterMenu.tsx`: updated types
- `src/components/MobileFilterDisplay.tsx`: updated types
- `src/components/RecipePageClient.tsx`: updated types
- `src/components/ViewRecipePopUp.tsx`: made the filter display support the new filter types. Added more filter sections, styling can always be changed if you think it doesn't look as good as it should.
- `src/database/ComboSchema.ts`: schema changes
- `src/database/RecipeSchema.ts`: schema changes
- `src/hooks/useMealData.ts`: supports the new query API for combos and recipes. instead of a list of tags, there are multiple param fields. e.g: `proteinSource=chicken&dietary=halal`
- `src/lib/server/comboHelpers.ts`: new server-only helpers file to handle the combo data derivation. Nutrition data derivation can happen here as well.
- `src/lib/helpers.ts`: moved a helper from menu planning page to here.
- `src/lib/types.ts`: added new types to deal with filtering. Basically, the goal is that now if there ever needs to be a category added or a filter added, all it takes is updating the types and constants. Anything that does need updating will fail to build. That way it is obvious what needs fixing.

### Testing Considerations
Verified the filtering behavior by creating new recipes, updating, making combos, searching, and filtering.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
Again, test data generated with chatgpt

<img width="844" height="617" alt="image" src="https://github.com/user-attachments/assets/30ea81c1-8636-4a4d-b698-54f7d4fbaf1d" />
<img width="1006" height="573" alt="image" src="https://github.com/user-attachments/assets/f83ae85d-ccbc-4e7e-8551-349d9dd0b261" />
<img width="746" height="305" alt="image" src="https://github.com/user-attachments/assets/d95ecce1-1985-44d5-bcb1-e33a41a2c274" />


