### PR TITLE
160 monthly drag drop

### DIFF
--- a/src/app/api/calendar/[id]/route.ts
+++ b/src/app/api/calendar/[id]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
+import "@/database/RecipeSchema";
 import Calendar from "@/database/CalendarSchema";
-import Recipe from "@/database/RecipeSchema";
 import { RECIPE_BUCKETS } from "@/lib/types";
-import type { RecipeBucket, RecipeBuckets } from "@/lib/types";
+import type { Recipe, RecipeBucket, RecipeBuckets } from "@/lib/types";
 
 type Params = {
   params: Promise<{
@@ -38,6 +38,8 @@ function getBucketIds(calendarDay: { get: (path: string) => unknown }, bucket: R
 }
 
 export async function GET(_req: NextRequest, { params }: Params) {
+  // Returns the fully populated calendar day.
+  // Buckets contain the entire recipe data, not just strings or preview.
   const { id } = await params;
 
   if (!id) {
@@ -47,52 +49,13 @@ export async function GET(_req: NextRequest, { params }: Params) {
   try {
     await connectDB();
 
-    const calendarDay = await Calendar.findById(id).exec();
+    const calendarDay = await Calendar.findById(id).populate(populateBucketPaths).lean().exec();
 
     if (!calendarDay) {
       return NextResponse.json({ error: "Calendar day not found" }, { status: 404 });
     }
 
-    const allIds = Array.from(new Set(RECIPE_BUCKETS.flatMap((bucket) => getBucketIds(calendarDay, bucket))));
-
-    const recipeDocs = await Recipe.find({ _id: { $in: allIds } })
-      .lean()
-      .exec();
-
-    const recipeLookup = new Map<string, CalendarRecipePreview>();
-
-    recipeDocs.forEach((doc) => {
-      if (doc._id) {
-        recipeLookup.set(doc._id.toString(), {
-          _id: doc._id.toString(),
-          name: doc.name,
-          serving: doc.serving,
-        });
-      }
-    });
-
-    const resolveRecipes = (ids: string[]) =>
-      ids.map((id) => recipeLookup.get(id) ?? { _id: id, name: id, serving: undefined });
-
-    const buckets = RECIPE_BUCKETS.reduce<RecipeBuckets<CalendarRecipePreview>>(
-      (acc, bucket) => {
-        acc[bucket] = resolveRecipes(getBucketIds(calendarDay, bucket));
-        return acc;
-      },
-      {
-        entrees: [],
-        vegetables: [],
-        fruits: [],
-        grains: [],
-      },
-    );
-
-    const response: CalendarDayResponse = {
-      _id: calendarDay._id.toString(),
-      ...buckets,
-    };
-
-    return NextResponse.json(response, { status: 200 });
+    return NextResponse.json(calendarDay, { status: 200 });
   } catch (err) {
     console.error("Error fetching calendar day:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
@@ -140,13 +103,13 @@ export async function DELETE(req: NextRequest, { params }: Params) {
 
   try {
     const body = await req.json();
-    const { recipeId, category } = body;
+    const { recipeId, category: bucket } = body;
 
-    if (!recipeId || !category) {
+    if (!recipeId || !bucket) {
       return NextResponse.json({ error: "recipeId and category are required" }, { status: 400 });
     }
 
-    if (!isRecipeBucket(category)) {
+    if (!isRecipeBucket(bucket)) {
       return NextResponse.json({ error: "Invalid category" }, { status: 400 });
     }
 
@@ -158,10 +121,10 @@ export async function DELETE(req: NextRequest, { params }: Params) {
       return NextResponse.json({ error: "Calendar day not found" }, { status: 404 });
     }
 
-    const currentIds = getBucketIds(calendarDay, category);
+    const currentIds = getBucketIds(calendarDay, bucket);
 
     calendarDay.set(
-      category,
+      bucket,
       currentIds.filter((itemId) => itemId !== recipeId),
     );
 

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Calendar from "@/database/CalendarSchema";
+import { RECIPE_BUCKETS } from "@/lib/types";
 
 export async function GET(req: NextRequest) {
   try {
@@ -9,21 +10,42 @@ export async function GET(req: NextRequest) {
     const searchParams = req.nextUrl.searchParams;
     const year = searchParams.get("year");
     const month = searchParams.get("month")?.padStart(2, "0");
+    const populate = searchParams.get("populate");
 
-    if (year && month) {
-      const yearMonth = `${year}${month}`;
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
 
-      const result = await Calendar.find({ _id: { $regex: `^${yearMonth}` } })
-        .populate("entrees")
-        .populate("vegetables")
-        .populate("fruits")
-        .populate("grains")
-        .exec();
+    const baseFilter =
+      year && month
+        ? {
+            _id: { $regex: `^${year}${month}` },
+          }
+        : {};
 
-      return NextResponse.json(result);
+    const query = Calendar.find(baseFilter);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    } else if (populate) {
+      return NextResponse.json(
+        {
+          error: "Invalid populate value. Use all, preview, nutrition, or filters.",
+        },
+        { status: 400 },
+      );
     }
 
-    const result = await Calendar.find().exec();
+    const result = await query.exec();
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error fetching calendar data:", error);

--- a/src/app/api/combos/[id]/route.ts
+++ b/src/app/api/combos/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
-import { RecipeBuckets } from "@/lib/types";
+import { RECIPE_BUCKETS, RecipeBuckets } from "@/lib/types";
 import { deriveComboDataFromRecipeIds, getFinalRecipeBuckets } from "@/lib/server/comboHelpers";
 
 type Params = {
@@ -17,7 +17,37 @@ export async function GET(req: NextRequest, { params }: Params) {
 
   try {
     await connectDB();
-    const combo = await Combo.findById(id);
+
+    const searchParams = req.nextUrl.searchParams;
+    const populate = searchParams.get("populate");
+
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
+
+    const query = Combo.findById(id);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    } else if (populate) {
+      return NextResponse.json(
+        {
+          error: "Invalid populate value. Use all, preview, nutrition, or filters.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const combo = await query.exec();
 
     if (!combo) {
       return NextResponse.json({ error: "Combo not found" }, { status: 404 });

--- a/src/app/api/combos/route.ts
+++ b/src/app/api/combos/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
 import Combo from "@/database/ComboSchema";
 import { getNormalizedParams } from "@/lib/server/searchParams";
-import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES } from "@/lib/types";
+import { DIETARY_KEYS, EXCLUSION_KEYS, PROTEIN_SOURCES, RECIPE_BUCKETS } from "@/lib/types";
 import { deriveComboDataFromRecipeIds, getRecipeBucketsFromBody } from "@/lib/server/comboHelpers";
 
 type ServingRange = {
@@ -33,12 +33,20 @@ export async function GET(req: NextRequest) {
 
     const isDraftParam = searchParams.get("isDraft");
     const sortBy = searchParams.get("sortBy") ?? "createdDate";
+    const populate = searchParams.get("populate");
 
     const proteinSourceParams = getNormalizedParams(searchParams, "proteinSources", PROTEIN_SOURCES);
 
     const dietaryParams = getNormalizedParams(searchParams, "dietary", DIETARY_KEYS);
 
     const exclusionParams = getNormalizedParams(searchParams, "exclusions", EXCLUSION_KEYS);
+
+    const populateSelectMap = {
+      // "all" just populates everything, no map needed
+      preview: "_id name category",
+      nutrition: "_id name category serving nutritional_info",
+      filters: "_id name serving category proteinSources dietary exclusions",
+    } as const;
 
     const servingParams = searchParams
       .getAll("servings")
@@ -124,6 +132,16 @@ export async function GET(req: NextRequest) {
       .sort(sort)
       .skip((page - 1) * limit)
       .limit(limit);
+
+    if (populate === "all") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket);
+      });
+    } else if (populate === "preview" || populate === "nutrition" || populate === "filters") {
+      RECIPE_BUCKETS.forEach((bucket) => {
+        query.populate(bucket, populateSelectMap[populate]);
+      });
+    }
 
     if (sortBy === "aToZ" || sortBy === "zToA") {
       query = query.collation({ locale: "en", strength: 2 });

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import MealBrowser from "@/components/MealBrowser";
 import FilterMenu from "@/components/FilterMenu";
-import { CategoryValue, createEmptyFilterSelections, FilterSelections } from "@/lib/types";
+import { CategoryValue, createEmptyFilterSelections, FilterSelections, RecipePreview } from "@/lib/types";
 import { useState, useEffect } from "react";
 import { ArrowLeft, Trash2, CircleX, CircleCheck, Menu } from "lucide-react";
 
@@ -24,11 +24,12 @@ export default function DraftsPage() {
   const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage, refresh } =
-    useMealData({
+    useMealData<RecipePreview>({
       search,
       filters,
       selectedCategories,
       draftMode: true,
+      comboPopulate: "preview",
     });
 
   useEffect(() => {

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -8,7 +8,7 @@ import RecipeDatabase from "@/components/menuPlanning/RecipeDatabase";
 import WeeklyNutritionQuota from "@/components/menuPlanning/WeeklyNutritionQuota";
 import DraggableRecipeCard from "@/components/menuPlanning/DraggableRecipeCard";
 import MonthView from "@/components/menuPlanning/MonthView";
-import DayView from "@/components/menuPlanning/DayView";
+import DayView, { DayMealCardPreview } from "@/components/menuPlanning/DayView";
 import CurrentDateButton from "@/components/CurrentDateButton";
 import { ChevronLeft, ChevronRight, ArrowDownToLine, GripVertical, Trash2 } from "lucide-react";
 import {
@@ -23,11 +23,14 @@ import {
   SortOption,
   createEmptyFilterSelections,
   CATEGORY_TO_BUCKET,
+  RecipeNutritionOnly,
 } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
 import xlsx, { IContent, IJsonSheet } from "json-as-xlsx";
 import { toggleCategory } from "@/lib/helpers";
+import DailyNutritionSummary from "@/components/menuPlanning/DailyNutritionSummary";
+import { MonthMealCardPreview } from "@/components/menuPlanning/MonthMealCard";
 
 const today = new Date();
 
@@ -54,7 +57,7 @@ export type SidebarDragData =
 
 export type CalendarDragData = {
   source: "calendar";
-  item: Recipe;
+  item: RecipeNutritionOnly;
   dayId: string;
 };
 
@@ -79,14 +82,16 @@ function TrashDropZone() {
   });
 
   return (
-    <div
-      ref={setNodeRef}
-      className={`flex h-14 w-14 items-center justify-center rounded-full bg-radish-900 text-white shadow-lg transition ${
-        isOver ? "scale-105 ring-4 ring-radish-900/20" : ""
-      }`}
-      aria-label="Trash"
-    >
-      <Trash2 size={24} strokeWidth={2.2} />
+    // some padding around the button to make the droppable area larger
+    <div ref={setNodeRef} className="flex h-24 w-24 items-center justify-center" aria-label="Trash drop zone">
+      <div
+        className={`flex h-14 w-14 items-center justify-center rounded-full bg-radish-900 text-white shadow-lg transition ${
+          isOver ? "scale-105 ring-4 ring-radish-900/20" : ""
+        }`}
+        aria-label="Trash"
+      >
+        <Trash2 size={24} strokeWidth={2.2} />
+      </div>
     </div>
   );
 }
@@ -98,7 +103,7 @@ function SidebarDropZone({ children }: { children: ReactNode }) {
   });
 
   return (
-    <div ref={setNodeRef} className="w-90">
+    <div ref={setNodeRef} className="flex flex-col w-90">
       {children}
     </div>
   );
@@ -199,7 +204,7 @@ export default function MenuPlanning() {
         throw new Error(`Failed to fetch monthly menu: ${res.status}`);
       }
 
-      const dates: CalendarDay[] = await res.json();
+      const dates: CalendarDay<RecipeNutritionOnly>[] = await res.json();
       const data: IContent[] = [];
 
       dates.forEach((date) => {
@@ -236,7 +241,7 @@ export default function MenuPlanning() {
 
         data.push(totals);
 
-        const pushItems = (items: Recipe[] = []) => {
+        const pushItems = (items: RecipeNutritionOnly[] = []) => {
           items.forEach((item) => {
             data.push({
               name: item.name,
@@ -421,10 +426,10 @@ export default function MenuPlanning() {
 
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
-      <main className="flex flex-row">
-        <div className="flex flex-1 items-center justify-center bg-gray-100">
-          <div className="flex h-full w-260 flex-col">
-            <div className="mt-4 flex items-center justify-between">
+      <main className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 justify-center pt-4 bg-gray-100 overflow-auto">
+          <div className="flex w-260 flex-col">
+            <div className="flex items-center justify-between">
               <div className="flex items-center justify-center gap-2">
                 <CurrentDateButton onClick={() => setDatesOffset(0)} />
 
@@ -499,8 +504,8 @@ export default function MenuPlanning() {
             </div>
 
             {calendarView === "Month" && (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <MonthView monthDates={viewDates} dateToday={today} />
+              <>
+                <MonthView monthDates={viewDates} dateToday={today} refetchTrigger={recipeDropTrigger} />
 
                 <div className="mt-2">
                   <WarningQuotaMonthly />
@@ -509,7 +514,7 @@ export default function MenuPlanning() {
                 <div className="mt-auto flex justify-end pb-4">
                   <TrashDropZone />
                 </div>
-              </div>
+              </>
             )}
 
             {calendarView === "Week" && (
@@ -524,7 +529,16 @@ export default function MenuPlanning() {
               </>
             )}
 
-            {calendarView === "Day" && <DayView date={viewDates[0]} refetchTrigger={recipeDropTrigger} />}
+            {calendarView === "Day" && (
+              <>
+                <DayView date={viewDates[0]} refetchTrigger={recipeDropTrigger} />
+                <div className="mt-2 flex justify-end">
+                  <TrashDropZone />
+                </div>
+
+                <DailyNutritionSummary recipes={[]} />
+              </>
+            )}
           </div>
         </div>
 
@@ -547,9 +561,15 @@ export default function MenuPlanning() {
 
       <DragOverlay>
         {activeId ? (
-          <div className="rotate-3 opacity-90">
+          <div className="opacity-80">
             {activeDragData?.source === "calendar" ? (
-              <CalendarDragPreview {...activeDragData} />
+              calendarView === "Month" ? (
+                <MonthMealCardPreview item={activeDragData.item} />
+              ) : calendarView === "Day" ? (
+                <DayMealCardPreview item={activeDragData.item} />
+              ) : (
+                <CalendarDragPreview {...activeDragData} />
+              )
             ) : activeDragData?.item ? (
               <DraggableRecipeCard item={activeDragData.item} disabled />
             ) : null}

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -22,6 +22,7 @@ import {
   RECIPE_BUCKETS,
   SortOption,
   createEmptyFilterSelections,
+  CATEGORY_TO_BUCKET,
 } from "@/lib/types";
 import { useMealData } from "@/hooks/useMealData";
 import WarningQuotaMonthly from "@/components/WarningQuotaMonthly";
@@ -39,38 +40,42 @@ const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
   { calories: 390, protein: 25, fat: 10, carbs: 48, fiber: 8, sodium: 530 }, // Fri
 ];
 
-// TODO: refine this a bit. Currently unsure how this is used
-type ActiveDragData = {
-  id: string; // Not the mongo _id... Probably remove
-  type?: string; // Always "recipe" or "trash", but "trash" is a drop zone, can probably remove.
+export type SidebarDragData =
+  | {
+      source: "sidebar";
+      itemType: "recipe";
+      item: Recipe;
+    }
+  | {
+      source: "sidebar";
+      itemType: "combo";
+      item: Combo;
+    };
 
-  source?: "sidebar" | "calendar"; // where the item was dragged from
-  itemType?: "recipe" | "combo";
-
-  recipeId?: string;
-  comboId?: string;
-  dayId?: string; // Used by the calendar drop zone, can probably remove from here then.
-
-  name?: string;
-  servingSize?: string;
-
-  // This is the plural of the category. e.g: "entrees", "vegetables"
-  bucket?: RecipeBucket; // now needed in the drag data, can be derived later
-  category?: CategoryValue;
-  recipeCategory?: RecipeCategory; // Simply excludes "combo" when we know it is a recipe
-
-  entrees?: string[];
-  vegetables?: string[];
-  fruits?: string[];
-  grains?: string[];
-
-  item?: Recipe | Combo; // We should honestly just include the item and category and forget about the rest of the attributes.
+export type CalendarDragData = {
+  source: "calendar";
+  item: Recipe;
+  dayId: string;
 };
+
+export type ActiveDragData = SidebarDragData | CalendarDragData;
+
+export type DropZoneData =
+  | {
+      dest: "calendar";
+      dayId: string;
+    }
+  | {
+      dest: "trash";
+    }
+  | {
+      dest: "sidebar";
+    };
 
 function TrashDropZone() {
   const { setNodeRef, isOver } = useDroppable({
-    id: "calendar-trash",
-    data: { type: "trash" },
+    id: "trash",
+    data: { dest: "trash" },
   });
 
   return (
@@ -88,7 +93,7 @@ function TrashDropZone() {
 
 function SidebarDropZone({ children }: { children: ReactNode }) {
   const { setNodeRef } = useDroppable({
-    id: "recipe-sidebar",
+    id: "sidebar",
     data: { type: "sidebar" },
   });
 
@@ -99,17 +104,15 @@ function SidebarDropZone({ children }: { children: ReactNode }) {
   );
 }
 
-function CalendarDragPreview({ name, servingSize, category, recipeCategory }: ActiveDragData) {
-  const displayCategory = category ?? recipeCategory;
-
+function CalendarDragPreview({ item }: CalendarDragData) {
   return (
     <div className="flex w-56 items-center gap-3 rounded-md bg-radish-900 px-4 py-3 font-montserrat text-white shadow-lg">
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[16px] leading-tight font-bold">{name}</p>
-        {servingSize ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{servingSize}</p> : null}
+        <p className="truncate text-[16px] leading-tight font-bold">{item.name}</p>
+        {item.serving ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{item.serving}</p> : null}
       </div>
 
-      {displayCategory ? <span className="shrink-0 text-xs font-medium">{displayCategory}</span> : null}
+      {item.category ? <span className="shrink-0 text-xs font-medium">{item.category}</span> : null}
 
       <GripVertical className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden="true" />
     </div>
@@ -303,8 +306,7 @@ export default function MenuPlanning() {
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveId(event.active.id as string);
     setActiveDragData({
-      id: event.active.id as string,
-      ...(event.active.data.current as Omit<ActiveDragData, "id">),
+      ...(event.active.data.current as ActiveDragData),
     });
   }, []);
 
@@ -316,15 +318,14 @@ export default function MenuPlanning() {
     if (!over) return;
 
     const dragData = active.data.current as ActiveDragData | undefined;
-    const dropData = over.data.current as { type?: string; dayId?: string } | undefined;
+    const dropData = over.data.current as DropZoneData | undefined;
 
-    if (dragData?.type === "recipe" && dragData.source === "calendar" && dropData?.type === "trash") {
-      const { recipeId, dayId, bucket } = dragData;
+    if (!dragData || !dropData) {
+      return;
+    }
 
-      if (!recipeId || !dayId || !bucket) {
-        console.error("Invalid calendar recipe drag data:", dragData);
-        return;
-      }
+    if (dragData.source === "calendar" && dropData.dest === "trash") {
+      const { item, dayId } = dragData;
 
       try {
         const response = await fetch(`/api/calendar/${dayId}`, {
@@ -333,8 +334,8 @@ export default function MenuPlanning() {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            recipeId,
-            category: bucket,
+            recipeId: item._id,
+            category: CATEGORY_TO_BUCKET[item.category],
           }),
         });
 
@@ -352,15 +353,19 @@ export default function MenuPlanning() {
       return;
     }
 
-    if (dragData?.type !== "recipe" || dropData?.type !== "calendar") {
+    if (dropData.dest !== "calendar") {
+      // dropping into the sidebar does nothing
+      // dopping into trash is handled above, dropping into calendar is handled below
       return;
     }
 
     if (dragData.source === "calendar") {
+      // Dragging from the calendar into anywhere else does nothing.
+      // E.g: cannot move a recipe between different days.
       return;
     }
 
-    const { dayId } = dropData;
+    const { dayId } = dropData; // here we are guaranteed to be dropped into calendar
 
     if (!dayId) {
       console.error("Missing calendar day id:", dropData);
@@ -368,15 +373,14 @@ export default function MenuPlanning() {
     }
 
     const calendarItemsToAdd: Array<{ recipeId: string; category: RecipeBucket }> =
+      // if combo, add the recipes in the combo. Otherwise just add the recipe.
       dragData.itemType === "combo"
         ? RECIPE_BUCKETS.flatMap((bucket) =>
-            (dragData[bucket] ?? [])
+            (dragData.item[bucket] ?? [])
               .filter((recipeId): recipeId is string => Boolean(recipeId?.trim()))
               .map((recipeId) => ({ recipeId, category: bucket })),
           )
-        : dragData.recipeId && dragData.bucket
-          ? [{ recipeId: dragData.recipeId, category: dragData.bucket }]
-          : [];
+        : [{ recipeId: dragData.item._id, category: CATEGORY_TO_BUCKET[dragData.item.category] }];
 
     if (calendarItemsToAdd.length === 0) {
       console.error("No valid recipes found in dragged item:", dragData);
@@ -391,10 +395,7 @@ export default function MenuPlanning() {
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({
-              recipeId: item.recipeId,
-              category: item.category,
-            }),
+            body: JSON.stringify(item),
           }),
         ),
       );

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -2,18 +2,18 @@ import RecipeCard from "@/components/RecipeCard";
 import ComboCard from "@/components/ComboCard";
 import DraftEntryCard from "@/components/DraftEntryCard";
 
-import { Recipe, Combo } from "@/lib/types";
+import { Recipe, Combo, RecipePreview } from "@/lib/types";
 
 type Props = {
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
-  items: Recipe[] | Combo[];
+  items: Recipe[] | Combo<RecipePreview>[];
   draftMode: boolean;
   draftCount: number;
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string, name: string) => void;
-  onOpenItem?: (item: Recipe | Combo) => void;
+  onOpenItem?: (item: Recipe | Combo<RecipePreview>) => void;
 };
 
 // FIXME: layouts are currently sortof broken (max 2 cols for some reason). Figure out why
@@ -39,7 +39,7 @@ export default function CardGrid({
       <div className="grid grid-cols-2 gap-3 md:gap-6 md:max-w-3xl">
         {!draftMode && <DraftEntryCard variant="Combo" numDrafts={draftCount} />}
 
-        {(items as Combo[]).map((combo) => (
+        {(items as Combo<RecipePreview>[]).map((combo) => (
           <ComboCard
             key={combo._id}
             item={combo}

--- a/src/components/CategoryToggle.tsx
+++ b/src/components/CategoryToggle.tsx
@@ -1,3 +1,4 @@
+import PillToggle from "@/components/PillToggle";
 import { CategoryDisplayType, CategoryValue } from "@/lib/types";
 
 export default function CategoryToggle({
@@ -9,27 +10,14 @@ export default function CategoryToggle({
   selectedCategories: Set<CategoryValue>;
   onToggle: (category: CategoryValue) => void;
 }) {
-  const baseClass =
-    "inline-flex items-center rounded-full border border-radish-900 px-3 py-1 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-radish-900";
-  const unselectedClass = "bg-white text-radish-900 hover:bg-radish-100";
-  const selectedClass = "bg-radish-900 text-white";
-
   return (
-    <div className="flex flex-wrap gap-2">
-      {options.map((option) => {
-        const selected = selectedCategories.has(option.category);
-
-        return (
-          <button
-            key={option.category}
-            type="button"
-            onClick={() => onToggle(option.category)}
-            className={`${baseClass} ${selected ? selectedClass : unselectedClass}`}
-          >
-            {option.plural}
-          </button>
-        );
-      })}
-    </div>
+    <PillToggle
+      options={options.map((option) => ({
+        value: option.category,
+        label: option.plural,
+      }))}
+      selectedValues={selectedCategories}
+      onToggle={onToggle}
+    />
   );
 }

--- a/src/components/ComboCard.tsx
+++ b/src/components/ComboCard.tsx
@@ -1,58 +1,57 @@
+"use client";
+
 import Image from "next/image";
 import { Pencil, Utensils } from "lucide-react";
-import { CATEGORY_DISPLAY, Combo, COMBO_CATEGORY_DISPLAY, Recipe, TAG_STYLES } from "@/lib/types";
-import { useEffect, useState } from "react";
+import { COMBO_CATEGORY_DISPLAY, Combo, Recipe, RecipePreview, TAG_STYLES } from "@/lib/types";
+import { useState } from "react";
 import CreateRecipePopUp from "./CreateRecipePopUp";
 
 type ComboCardProps = {
-  item: Combo;
+  item: Combo<RecipePreview>;
   isSelected?: boolean;
   onSelect?: () => void;
   onOpen?: () => void;
 };
 
-export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboCardProps) {
-  const [editMode, setEditMode] = useState(false);
-  const [entreeMap, setEntreeMap] = useState<string[]>([]);
-  const [vegetableMap, setVegetableMap] = useState<string[]>([]);
-  const [fruitMap, setFruitMap] = useState<string[]>([]);
-  const [grainMap, setGrainMap] = useState<string[]>([]);
+async function getCombo(id: string): Promise<Combo<Recipe>> {
+  const res = await fetch(`/api/combos/${id}?populate=all`);
 
-  const entrees = item.entrees ?? [];
-  const vegetables = item.vegetables ?? [];
-  const fruits = item.fruits ?? [];
-  const grains = item.grains ?? [];
-
-  async function getRecipe(id: string): Promise<Recipe> {
-    const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
-    return res.json();
+  if (!res.ok) {
+    throw new Error(`Failed to get combo (${res.status})`);
   }
 
-  useEffect(() => {
-    const loadAll = async () => {
-      try {
-        const [entreeNames, vegetableNames, fruitNames, grainNames] = await Promise.all([
-          Promise.all(entrees.map(async (e) => (await getRecipe(e)).name)),
-          Promise.all(vegetables.map(async (v) => (await getRecipe(v)).name)),
-          Promise.all(fruits.map(async (f) => (await getRecipe(f)).name)),
-          Promise.all(grains.map(async (g) => (await getRecipe(g)).name)),
-        ]);
+  return res.json();
+}
 
-        setEntreeMap(entreeNames);
-        setVegetableMap(vegetableNames);
-        setFruitMap(fruitNames);
-        setGrainMap(grainNames);
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return;
-        console.error("Failed to load combo recipe names:", err);
-      }
-    };
+export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboCardProps) {
+  const [editMode, setEditMode] = useState(false);
+  const [editItem, setEditItem] = useState<Combo<Recipe> | null>(null);
+  const [isLoadingEditItem, setIsLoadingEditItem] = useState(false);
 
-    loadAll();
-  }, []);
+  const recipes = [...(item.entrees ?? []), ...(item.vegetables ?? []), ...(item.fruits ?? []), ...(item.grains ?? [])];
 
   const servingText = item.serving != null ? `${item.serving}` : null;
+
+  const handleEditClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (editItem) {
+      setEditMode(true);
+      return;
+    }
+
+    setIsLoadingEditItem(true);
+
+    try {
+      const fullCombo = await getCombo(item._id);
+      setEditItem(fullCombo);
+      setEditMode(true);
+    } catch (error) {
+      console.error("Failed to load combo for editing:", error);
+    } finally {
+      setIsLoadingEditItem(false);
+    }
+  };
 
   return (
     <div
@@ -70,23 +69,22 @@ export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboC
           <Image src={item.imageUrl} className="h-full w-full object-cover" fill sizes="288px" alt="" />
         ) : null}
 
-        {editMode === true && (
+        {editMode && editItem ? (
           <CreateRecipePopUp
             onClose={() => setEditMode(false)}
-            item={item}
+            item={editItem}
             open={true}
             recipeType={COMBO_CATEGORY_DISPLAY}
             editMode={true}
           />
-        )}
+        ) : null}
 
         {item.isDraft && (
           <Pencil
-            className="absolute top-35 right-4 z-20 h-5 w-5 cursor-pointer rounded-xs accent-radish-900"
-            onClick={(e) => {
-              e.stopPropagation();
-              setEditMode((prev) => !prev);
-            }}
+            className={`absolute top-35 right-4 z-20 h-5 w-5 cursor-pointer rounded-xs accent-radish-900 ${
+              isLoadingEditItem ? "opacity-50" : ""
+            }`}
+            onClick={handleEditClick}
           />
         )}
 
@@ -117,39 +115,14 @@ export default function ComboCard({ item, isSelected, onSelect, onOpen }: ComboC
           <p className="mt-3 font-montserrat text-base font-bold">{item.name}</p>
 
           <div className="flex max-h-30 flex-col gap-1.5 overflow-y-auto">
-            {entreeMap.map((i) => (
+            {recipes.map((recipe) => (
               <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Entree}`}
+                key={`${recipe.category}-${recipe._id}`}
+                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${
+                  TAG_STYLES[recipe.category]
+                }`}
               >
-                {i}
-              </span>
-            ))}
-
-            {vegetableMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Vegetable}`}
-              >
-                {i}
-              </span>
-            ))}
-
-            {fruitMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Fruit}`}
-              >
-                {i}
-              </span>
-            ))}
-
-            {grainMap.map((i) => (
-              <span
-                key={i}
-                className={`inline-flex w-fit shrink-0 rounded-md px-3 py-1.5 font-montserrat text-xs font-medium ${TAG_STYLES.Grain}`}
-              >
-                {i}
+                {recipe.name}
               </span>
             ))}
           </div>

--- a/src/components/CreateRecipePopUp.tsx
+++ b/src/components/CreateRecipePopUp.tsx
@@ -34,8 +34,11 @@ import { DropdownField } from "./createRecipe/DropdownField";
 
 // TODO: this whole thing should be split into Create Combo / Create Recipe subcomponents and helpers should be moved to helpers.ts
 
+type EditableCombo = Combo<Recipe>;
+type EditableItem = Recipe | EditableCombo;
+
 type Props = {
-  item: Recipe | Combo | null;
+  item: EditableItem | null;
   open: boolean;
   onClose: () => void;
   recipeType: CategoryDisplayType | null;
@@ -48,8 +51,15 @@ type InputPair = {
   units: string;
 };
 
-function isRecipeItem(item: Recipe | Combo): item is Recipe {
+function isRecipeItem(item: EditableItem): item is Recipe {
   return "category" in item;
+}
+
+function toRecipeMinimal(recipes: Recipe[] = []): RecipeMinimal[] {
+  return recipes.map((recipe) => ({
+    _id: recipe._id,
+    name: recipe.name,
+  }));
 }
 
 function comboHasRecipe(combo: Combo, recipeId: string) {
@@ -179,12 +189,6 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
     setIngredientInputs(updated);
   };
 
-  async function getRecipe(id: string): Promise<Recipe> {
-    const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
-    return res.json();
-  }
-
   useEffect(() => {
     if (!open) return;
 
@@ -243,41 +247,11 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
           fiber: item.nutritional_info.fiber.toString(),
           sodium: item.nutritional_info.sodium.toString(),
         });
-      } else if (isCombo && isRecipeItem(item) === false) {
-        const loadAll = async () => {
-          const [entreeNames, vegetableNames, fruitNames, grainNames] = await Promise.all([
-            Promise.all(
-              (item.entrees ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.vegetables ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.fruits ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-            Promise.all(
-              (item.grains ?? []).map(async (id) => {
-                const recipe = await getRecipe(id);
-                return { _id: recipe._id, name: recipe.name };
-              }),
-            ),
-          ]);
-
-          setSelectedEntree(entreeNames);
-          setSelectedVegetables(vegetableNames);
-          setSelectedFruit(fruitNames);
-          setSelectedGrains(grainNames);
-        };
-        loadAll();
+      } else if (isCombo && !isRecipeItem(item)) {
+        setSelectedEntree(toRecipeMinimal(item.entrees));
+        setSelectedVegetables(toRecipeMinimal(item.vegetables));
+        setSelectedFruit(toRecipeMinimal(item.fruits));
+        setSelectedGrains(toRecipeMinimal(item.grains));
       }
 
       setId(item._id);

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -4,12 +4,12 @@ import CategoryToggle from "@/components/CategoryToggle";
 import CardGrid from "@/components/CardGrid";
 import AddNewRecipeButton from "@/components/AddNewRecipeButton";
 import PaginationDisplay from "@/components/PaginationDisplay";
-import { CATEGORY_DISPLAY, CategoryValue, Combo, Recipe } from "@/lib/types";
+import { CATEGORY_DISPLAY, CategoryValue, Combo, Recipe, RecipePreview } from "@/lib/types";
 import { toggleCategory } from "@/lib/helpers";
 
 type Props = {
   setSearch: (s: string) => void;
-  items: Recipe[] | Combo[];
+  items: Recipe[] | Combo<RecipePreview>[];
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
@@ -24,7 +24,7 @@ type Props = {
 
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string, name: string) => void;
-  onOpenItem?: (item: Recipe | Combo) => void;
+  onOpenItem?: (item: Recipe | Combo<RecipePreview>) => void;
 
   topLeftChildren?: ReactNode; // top-left slot for an extra button
   topRightChildren?: ReactNode; // for additional buttons after search bar

--- a/src/components/PermissionsClient.tsx
+++ b/src/components/PermissionsClient.tsx
@@ -1,35 +1,101 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import SearchBarClient from "@/components/SearchbarClient";
 import PermissionsDisplay from "@/components/PermissionsDisplay";
 import SortPermissionsButton from "@/components/SortPermissionsButton";
+import PaginationDisplay from "@/components/PaginationDisplay";
+import PillToggle from "@/components/PillToggle";
+import { USER_ROLES, type UserRole } from "@/lib/types";
 import { UserPerms } from "@/components/IndividualPermission";
 
 interface PermissionsClientProps {
   users: UserPerms[];
 }
 
+const PAGE_SIZE = 5;
+
 export default function PermissionsClient({ users }: PermissionsClientProps) {
   const [search, setSearch] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedRoles, setSelectedRoles] = useState<Set<UserRole>>(new Set());
 
+  /* TODO: Delete this local filtering/pagination once permissions are fetched from the API.
+   * Eventually the API should receive: search, selectedRoles, currentPage, PAGE_SIZE.
+   */
   const filteredUsers = useMemo(() => {
     const query = search.trim().toLowerCase();
-    if (!query) return users;
 
     return users.filter((user) => {
-      const parts = user.name.toLowerCase().split(" ");
-      return parts.some((part) => part.includes(query)) || user.name.toLowerCase().includes(query);
+      const name = user.name.toLowerCase();
+      const matchesSearch = !query || name.includes(query) || name.split(" ").some((part) => part.includes(query));
+
+      const matchesRole = selectedRoles.size === 0 || selectedRoles.has(user.role as UserRole);
+
+      return matchesSearch && matchesRole;
     });
-  }, [search, users]);
+  }, [search, selectedRoles, users]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredUsers.length / PAGE_SIZE));
+
+  const paginatedUsers = useMemo(() => {
+    const startIndex = (currentPage - 1) * PAGE_SIZE;
+    const endIndex = startIndex + PAGE_SIZE;
+
+    return filteredUsers.slice(startIndex, endIndex);
+  }, [filteredUsers, currentPage]);
+  /* End temporary local filtering/pagination */
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [search, selectedRoles]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const toggleRole = (role: UserRole) => {
+    setSelectedRoles((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(role)) {
+        next.delete(role);
+      } else {
+        next.add(role);
+      }
+
+      return next;
+    });
+  };
 
   return (
     <div className="p-5">
-      <div className="flex items-center gap-3 mb-5">
+      <div className="mb-5 flex items-center gap-3">
         <SearchBarClient placeholder="Search a user" onSearch={setSearch} />
         <SortPermissionsButton align="right" />
       </div>
-      <PermissionsDisplay users={filteredUsers} editing={true} />
+
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <PillToggle
+          options={USER_ROLES.map((role) => ({
+            value: role,
+            label: role,
+          }))}
+          selectedValues={selectedRoles}
+          onToggle={toggleRole}
+        />
+
+        <PaginationDisplay
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+          disabled={false}
+        />
+      </div>
+
+      <PermissionsDisplay users={paginatedUsers} editing={true} />
     </div>
   );
 }

--- a/src/components/PillToggle.tsx
+++ b/src/components/PillToggle.tsx
@@ -1,0 +1,36 @@
+type PillToggleOption<T extends string> = {
+  value: T;
+  label: string;
+};
+
+type PillToggleProps<T extends string> = {
+  options: PillToggleOption<T>[];
+  selectedValues: Set<T>;
+  onToggle: (value: T) => void;
+};
+
+export default function PillToggle<T extends string>({ options, selectedValues, onToggle }: PillToggleProps<T>) {
+  const baseClass =
+    "inline-flex items-center rounded-full border border-radish-900 px-3 py-1 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-radish-900";
+  const unselectedClass = "bg-white text-radish-900 hover:bg-radish-100";
+  const selectedClass = "bg-radish-900 text-white";
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const selected = selectedValues.has(option.value);
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onToggle(option.value)}
+            className={`${baseClass} ${selected ? selectedClass : unselectedClass}`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -10,6 +10,7 @@ import {
   COMBO_CATEGORY_DISPLAY,
   createEmptyFilterSelections,
   FilterSelections,
+  RecipePreview,
 } from "@/lib/types";
 import { useEffect, useState } from "react";
 import { useMealData } from "@/hooks/useMealData";
@@ -18,41 +19,79 @@ import { SlidersHorizontal } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { cloneFilterSelections } from "@/lib/helpers";
 
+type BrowserItem = Recipe | Combo<RecipePreview>;
+type SelectedItem = Recipe | Combo<Recipe>;
+
+function isRecipe(item: BrowserItem | SelectedItem): item is Recipe {
+  return "category" in item;
+}
+
 export default function RecipePageClient() {
   const searchParams = useSearchParams();
   const id = searchParams.get("id");
 
-  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections()); // Lazy initializer, only used on first render.
+  const [filters, setFilters] = useState<FilterSelections>(() => createEmptyFilterSelections());
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
   const [search, setSearch] = useState("");
-  const [selectedItem, setSelectedItem] = useState<Recipe | Combo | null>(null);
+  const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [activeType, setActiveType] = useState<CategoryDisplayType | null>(null);
 
   async function getRecipe(id: string): Promise<Recipe> {
     const res = await fetch(`/api/recipes/${id}`);
-    if (!res.ok) throw new Error(`Failed to get individual recipe (${res.status})`);
+
+    if (!res.ok) {
+      throw new Error(`Failed to get individual recipe (${res.status})`);
+    }
+
     return res.json();
   }
 
-  const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage } = useMealData({
-    search,
-    filters,
-    selectedCategories,
-    draftMode: false,
-  });
+  async function getCombo(id: string): Promise<Combo<Recipe>> {
+    const res = await fetch(`/api/combos/${id}?populate=all`);
 
-  const handleOpenItem = (item: Recipe | Combo) => {
-    setSelectedItem(item);
-    setIsOpen(true);
-    setActiveType(isComboMode ? COMBO_CATEGORY_DISPLAY : null);
+    if (!res.ok) {
+      throw new Error(`Failed to get individual combo (${res.status})`);
+    }
+
+    return res.json();
+  }
+
+  const { items, loading, error, isComboMode, draftCount, currentPage, totalPages, setCurrentPage } =
+    useMealData<RecipePreview>({
+      search,
+      filters,
+      selectedCategories,
+      draftMode: false,
+      comboPopulate: "preview",
+    });
+
+  const handleOpenItem = async (item: BrowserItem) => {
+    setMode("view");
+
+    if (isRecipe(item)) {
+      setSelectedItem(item);
+      setActiveType(null);
+      setIsOpen(true);
+      return;
+    }
+
+    try {
+      const combo = await getCombo(item._id);
+
+      setSelectedItem(combo);
+      setActiveType(COMBO_CATEGORY_DISPLAY);
+      setIsOpen(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   useEffect(() => {
-    if (!id || id === "") return;
-    // fetch recipe item
+    if (!id) return;
+
     getRecipe(id)
       .then((recipe) => {
         setSelectedItem(recipe);
@@ -64,6 +103,8 @@ export default function RecipePageClient() {
         console.error(err);
       });
   }, [id]);
+
+  const selectedItemIsCombo = selectedItem ? !isRecipe(selectedItem) : isComboMode;
 
   return (
     <main className="relative flex min-h-0 flex-1 flex-col gap-6 overflow-hidden px-5 pt-5 md:flex-row">
@@ -116,7 +157,7 @@ export default function RecipePageClient() {
           open={isOpen}
           onClose={setIsOpen}
           item={selectedItem}
-          isComboMode={isComboMode}
+          isComboMode={selectedItemIsCombo}
           changeMode={(e) => setMode(e)}
         />
       ) : (

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { DIETARY_KEYS, EXCLUSION_KEYS, FILTER_SECTIONS, TAG_STYLES } from "@/lib/types";
+import {
+  DIETARY_KEYS,
+  ENTREE_ICON,
+  EXCLUSION_KEYS,
+  FILTER_SECTIONS,
+  FRUIT_ICON,
+  GRAIN_ICON,
+  RECIPE_BUCKETS,
+  TAG_STYLES,
+  VEGETABLE_ICON,
+} from "@/lib/types";
 import type {
   Combo,
   CategoryValue,
@@ -9,6 +19,7 @@ import type {
   MealFilterFields,
   Nutrition,
   Recipe,
+  RecipeBuckets,
   RecipeCategory,
 } from "@/lib/types";
 import {
@@ -16,8 +27,6 @@ import {
   Maximize2,
   Pencil,
   Ellipsis,
-  Carrot,
-  Apple,
   Tag,
   CircleAlert,
   SquarePen,
@@ -31,23 +40,9 @@ import NutritionalInfo from "./NutrionalInfo";
 type Props = {
   open: boolean;
   onClose: (v: boolean) => void;
-  item: Recipe | Combo | null;
+  item: Recipe | Combo<Recipe> | null;
   isComboMode: boolean;
   changeMode: (mode: "view" | "edit") => void;
-};
-
-type ComboRecipeMap = {
-  entrees: Recipe[];
-  vegetables: Recipe[];
-  fruits: Recipe[];
-  grains: Recipe[];
-};
-
-const EMPTY_COMBO_RECIPE_MAP: ComboRecipeMap = {
-  entrees: [],
-  vegetables: [],
-  fruits: [],
-  grains: [],
 };
 
 function emptyNutrition(): Nutrition {
@@ -88,27 +83,8 @@ function formatNutritionValue(value: number, originalServings: number, servings:
   return Number.isInteger(scaled) ? scaled.toString() : scaled.toFixed(1);
 }
 
-async function getRecipe(id: string, signal?: AbortSignal): Promise<Recipe> {
-  const res = await fetch(`/api/recipes/${id}`, { signal });
-
-  if (!res.ok) {
-    throw new Error(`Failed to get individual recipe (${res.status})`);
-  }
-
-  return res.json();
-}
-
-async function getRecipes(ids: string[] = [], signal?: AbortSignal): Promise<Recipe[]> {
-  return Promise.all(ids.map((id) => getRecipe(id, signal)));
-}
-
-function getComboNutrition(comboRecipes: ComboRecipeMap, comboServing: number): Nutrition {
-  const allRecipes = [
-    ...comboRecipes.entrees,
-    ...comboRecipes.vegetables,
-    ...comboRecipes.fruits,
-    ...comboRecipes.grains,
-  ];
+function getComboNutrition(comboRecipes: RecipeBuckets<Recipe>, comboServing: number): Nutrition {
+  const allRecipes = RECIPE_BUCKETS.flatMap((bucket) => comboRecipes[bucket] ?? []);
 
   const nutritionPerServing = allRecipes.reduce((total, recipe) => {
     const recipeServing = Math.max(1, recipe.serving || 1);
@@ -189,7 +165,7 @@ export default function ViewRecipePopUp({ open, onClose, item, isComboMode, chan
 
             {isComboMode ? (
               <ComboDetails
-                combo={item as Combo}
+                combo={item as Combo<Recipe>}
                 servings={servings}
                 setServings={setServings}
                 originalServings={originalServings}
@@ -272,54 +248,19 @@ function ComboDetails({
   setServings,
   originalServings,
 }: {
-  combo: Combo;
+  combo: Combo<Recipe>;
   servings: number;
   setServings: React.Dispatch<React.SetStateAction<number>>;
   originalServings: number;
 }) {
-  const [comboRecipes, setComboRecipes] = useState<ComboRecipeMap>(EMPTY_COMBO_RECIPE_MAP);
-
-  const nutrition = useMemo(() => getComboNutrition(comboRecipes, combo.serving), [comboRecipes, combo.serving]);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    async function loadComboRecipes() {
-      try {
-        setComboRecipes(EMPTY_COMBO_RECIPE_MAP);
-
-        const [entrees, vegetables, fruits, grains] = await Promise.all([
-          getRecipes(combo.entrees, controller.signal),
-          getRecipes(combo.vegetables, controller.signal),
-          getRecipes(combo.fruits, controller.signal),
-          getRecipes(combo.grains, controller.signal),
-        ]);
-
-        setComboRecipes({
-          entrees,
-          vegetables,
-          fruits,
-          grains,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return;
-
-        console.error("Failed to load combo recipes:", err);
-        setComboRecipes(EMPTY_COMBO_RECIPE_MAP);
-      }
-    }
-
-    loadComboRecipes();
-
-    return () => controller.abort();
-  }, [combo]);
+  const nutrition = useMemo(() => getComboNutrition(combo, combo.serving), [combo]);
 
   return (
     <>
-      <RecipeGroup label="Entrees" icon={<Carrot />} items={comboRecipes.entrees} styleKey="Entree" />
-      <RecipeGroup label="Vegetables" icon={<Carrot />} items={comboRecipes.vegetables} styleKey="Vegetable" />
-      <RecipeGroup label="Fruits" icon={<Apple />} items={comboRecipes.fruits} styleKey="Fruit" />
-      <RecipeGroup label="Grains" icon={<Tag />} items={comboRecipes.grains} styleKey="Grain" />
+      <RecipeGroup label="Entrees" icon={<ENTREE_ICON />} items={combo.entrees} styleKey="Entree" />
+      <RecipeGroup label="Vegetables" icon={<VEGETABLE_ICON />} items={combo.vegetables} styleKey="Vegetable" />
+      <RecipeGroup label="Fruits" icon={<FRUIT_ICON />} items={combo.fruits} styleKey="Fruit" />
+      <RecipeGroup label="Grains" icon={<GRAIN_ICON />} items={combo.grains} styleKey="Grain" />
 
       <MealFiltersSection item={combo} />
 

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -1,28 +1,28 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Trash2 } from "lucide-react";
+import { GripVertical, Trash2 } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
 import DroppableCalendarArea from "./DroppableCalendarArea";
-import DailyNutritionSummary from "./DailyNutritionSummary";
-import { BUCKET_TO_CATEGORY, Nutrition, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
-import type { Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
+import { CATEGORY_TO_BUCKET, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
+import type { Recipe, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
+import type { CalendarDragData } from "@/app/menuPlanning/page";
 
 interface DayViewProps {
   date: Date;
   refetchTrigger?: number;
 }
 
-type DayMeal = {
-  id: string;
-  name: string;
-  servingSize?: string;
-  tag: RecipeCategory;
-  category: RecipeBucket;
-};
-
 type CalendarDayResponse = {
   _id: string;
 } & RecipeBuckets<Recipe>;
+
+type DayMealCardProps = {
+  item: RecipeNutritionOnly;
+  dayId: string;
+  deletingId: string | null;
+  onDelete: (meal: RecipeNutritionOnly) => void;
+};
 
 const formatDayId = (date: Date) => {
   const year = date.getFullYear();
@@ -32,8 +32,111 @@ const formatDayId = (date: Date) => {
   return `${year}${month}${day}`;
 };
 
+export type DayMealCardPreviewProps = {
+  item: RecipeNutritionOnly;
+};
+
+export function DayMealCardPreview({ item }: DayMealCardPreviewProps) {
+  const tagClassName = TAG_STYLES[item.category];
+
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 shadow-lg">
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate font-montserrat text-xl font-bold" title={item.name}>
+          {item.name}
+        </h3>
+
+        {metaText ? <p className="font-montserrat text-base font-medium text-pepper/70">{metaText}</p> : null}
+      </div>
+
+      <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagClassName}`}>
+        {item.category}
+      </span>
+
+      <GripVertical className="h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
+    </div>
+  );
+}
+
+function DayMealCard({ item, dayId, deletingId, onDelete }: DayMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
+  const isDeleting = deletingId === item._id;
+
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
+
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, isDragging } = useDraggable({
+    id: dndId,
+    data: dragData,
+    disabled: isDeleting,
+  });
+
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md ${
+        isDragging ? "opacity-40" : ""
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate font-montserrat text-xl font-bold" title={item.name}>
+          {item.name}
+        </h3>
+
+        {metaText ? <p className="font-montserrat text-base font-medium text-pepper/70">{metaText}</p> : null}
+      </div>
+
+      <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagClassName}`}>
+        {item.category}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => onDelete(item)}
+        disabled={isDeleting}
+        className="shrink-0 rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
+        aria-label={`Remove ${item.name}`}
+      >
+        <Trash2 size={18} strokeWidth={1.7} />
+      </button>
+
+      <button
+        // Only the vertical grip starts a drag, since otherwise the trashcan button would also drag
+        // Makes it easier to implement linking to the recipe on click later as well.
+        ref={setActivatorNodeRef}
+        type="button"
+        className="shrink-0 cursor-move rounded-md p-1.5 text-gray-500 transition hover:bg-gray-100"
+        aria-label={`Drag ${item.name}`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={20} strokeWidth={1.7} />
+      </button>
+    </div>
+  );
+}
+
 export default function DayView({ date, refetchTrigger }: DayViewProps) {
-  const [meals, setMeals] = useState<DayMeal[]>([]);
+  const [meals, setMeals] = useState<Recipe[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
@@ -55,19 +158,7 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
       }
 
       const calendarDay: CalendarDayResponse = await response.json();
-
-      const nextMeals = RECIPE_BUCKETS.flatMap((bucket) => {
-        const recipes = calendarDay[bucket] ?? [];
-        const tag = BUCKET_TO_CATEGORY[bucket];
-
-        return recipes.map((recipe) => ({
-          id: recipe._id,
-          name: recipe.name,
-          servingSize: recipe.serving != null ? `${recipe.serving} servings` : undefined,
-          tag,
-          category: bucket,
-        }));
-      });
+      const nextMeals = RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
 
       setMeals(nextMeals);
     } catch (error) {
@@ -82,16 +173,16 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
     fetchDayMeals();
   }, [fetchDayMeals, refetchTrigger]);
 
-  const handleDelete = async (meal: DayMeal) => {
-    setDeletingId(meal.id);
+  const handleDelete = async (meal: RecipeNutritionOnly) => {
+    setDeletingId(meal._id);
 
     try {
       const response = await fetch(`/api/calendar/${dayId}`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          recipeId: meal.id,
-          category: meal.category,
+          recipeId: meal._id,
+          category: CATEGORY_TO_BUCKET[meal.category],
         }),
       });
 
@@ -99,7 +190,7 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
         throw new Error("Failed to delete recipe from calendar");
       }
 
-      setMeals((prev) => prev.filter((m) => !(m.id === meal.id && m.category === meal.category)));
+      setMeals((prev) => prev.filter((m) => !(m._id === meal._id && m.category === meal.category)));
     } catch (error) {
       console.error("Error deleting recipe from calendar:", error);
     } finally {
@@ -107,57 +198,31 @@ export default function DayView({ date, refetchTrigger }: DayViewProps) {
     }
   };
 
-  const emptyNutrition: Nutrition[] = [];
-
   return (
-    <div className="mt-4 flex flex-col gap-3">
-      <DroppableCalendarArea dayId={dayId}>
-        {isLoading ? (
-          <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 py-8 text-center font-montserrat text-xs font-medium text-pepper/55">
-            Loading meals...
-          </div>
-        ) : meals.length > 0 ? (
-          meals.map((meal) => {
-            const tagStyle = TAG_STYLES[meal.tag];
-
-            return (
-              <div
-                key={`${meal.id}-${meal.category}`}
-                className="flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md"
-              >
-                <div className="min-w-0 flex-1">
-                  <h3 className="truncate font-montserrat text-xl font-bold" title={meal.name}>
-                    {meal.name}
-                  </h3>
-
-                  {meal.servingSize ? (
-                    <p className="font-montserrat text-base font-medium text-pepper/70">{meal.servingSize}</p>
-                  ) : null}
-                </div>
-
-                <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagStyle}`}>
-                  {meal.tag}
-                </span>
-
-                <button
-                  onClick={() => handleDelete(meal)}
-                  disabled={deletingId === meal.id}
-                  className="shrink-0 rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
-                  aria-label={`Remove ${meal.name}`}
-                >
-                  <Trash2 size={18} strokeWidth={1.7} />
-                </button>
-              </div>
-            );
-          })
-        ) : (
-          <div className="flex flex-1 items-center justify-center py-8 text-center font-montserrat text-sm font-medium text-pepper/55">
-            Drop a recipe here to add it to today&apos;s menu
-          </div>
-        )}
-      </DroppableCalendarArea>
-
-      <DailyNutritionSummary recipes={emptyNutrition} />
+    <div className="flex flex-col gap-3 pt-4">
+      <div className="rounded-[14px] p-3 bg-white border border-medium-gray/35">
+        <DroppableCalendarArea dayId={dayId}>
+          {isLoading ? (
+            <div className="flex flex-1 items-center justify-center rounded-[10px] border border-dashed border-pepper/15 bg-white/55 px-3 py-8 text-center font-montserrat text-xs font-medium text-pepper/55">
+              Loading meals...
+            </div>
+          ) : meals.length > 0 ? (
+            meals.map((meal) => (
+              <DayMealCard
+                key={`${dayId}-${meal._id}`}
+                item={meal}
+                dayId={dayId}
+                deletingId={deletingId}
+                onDelete={handleDelete}
+              />
+            ))
+          ) : (
+            <div className="flex flex-1 items-center justify-center py-8 text-center font-montserrat text-sm font-medium text-pepper/55">
+              Drop a recipe here to add it to today&apos;s menu
+            </div>
+          )}
+        </DroppableCalendarArea>
+      </div>
     </div>
   );
 }

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -5,7 +5,7 @@ import { Trash2 } from "lucide-react";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 import DailyNutritionSummary from "./DailyNutritionSummary";
 import { BUCKET_TO_CATEGORY, Nutrition, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
-import type { RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
+import type { Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
 
 interface DayViewProps {
   date: Date;
@@ -20,15 +20,9 @@ type DayMeal = {
   category: RecipeBucket;
 };
 
-type CalendarRecipe = {
-  _id: string;
-  name: string;
-  serving?: number;
-};
-
 type CalendarDayResponse = {
   _id: string;
-} & Partial<RecipeBuckets<CalendarRecipe>>;
+} & RecipeBuckets<Recipe>;
 
 const formatDayId = (date: Date) => {
   const year = date.getFullYear();

--- a/src/components/menuPlanning/DraggableRecipeCard.tsx
+++ b/src/components/menuPlanning/DraggableRecipeCard.tsx
@@ -3,7 +3,8 @@
 import Image from "next/image";
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
-import { CATEGORY_TO_BUCKET, CategoryValue, Combo, Recipe, TAG_STYLES } from "@/lib/types";
+import { CategoryValue, Combo, Recipe, TAG_STYLES } from "@/lib/types";
+import type { SidebarDragData } from "@/app/menuPlanning/page";
 
 type DraggableRecipeCardProps = {
   item: Recipe | Combo;
@@ -25,34 +26,22 @@ export default function DraggableRecipeCard({ item, disabled = false }: Draggabl
   const servingText = item.serving != null ? `${item.serving}` : null;
   const metaText = caloriesText && servingText ? `${caloriesText} / ${servingText}` : caloriesText || servingText;
 
+  const dragData: SidebarDragData = itemIsRecipe
+    ? {
+        source: "sidebar",
+        itemType: "recipe",
+        item,
+      }
+    : {
+        source: "sidebar",
+        itemType: "combo",
+        item,
+      };
+
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `sidebar-${itemType}-${item._id}`,
     disabled,
-    data: itemIsRecipe
-      ? {
-          type: "recipe",
-          source: "sidebar",
-          itemType: "recipe",
-          recipeId: item._id,
-          name: item.name,
-          bucket: CATEGORY_TO_BUCKET[item.category],
-          category: item.category,
-          recipeCategory: item.category,
-          item,
-        }
-      : {
-          type: "recipe",
-          source: "sidebar",
-          itemType: "combo",
-          comboId: item._id,
-          name: item.name,
-          category: "Combo",
-          entrees: item.entrees,
-          vegetables: item.vegetables,
-          fruits: item.fruits,
-          grains: item.grains,
-          item,
-        },
+    data: dragData,
   });
 
   return (

--- a/src/components/menuPlanning/DroppableCalendarArea.tsx
+++ b/src/components/menuPlanning/DroppableCalendarArea.tsx
@@ -22,7 +22,7 @@ export default function DroppableCalendarArea({ dayId, children }: DroppableCale
   return (
     <div
       ref={setNodeRef}
-      className={`flex h-full min-h-55 w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
+      className={`flex h-full w-full flex-1 flex-col gap-2 rounded-[10px] p-4 transition-colors ${
         isOver ? "bg-radish-100 border-2 border-radish-900" : "border border-medium-gray/20 bg-white/30"
       }`}
     >

--- a/src/components/menuPlanning/DroppableCalendarArea.tsx
+++ b/src/components/menuPlanning/DroppableCalendarArea.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type { DropZoneData } from "@/app/menuPlanning/page";
 import { useDroppable } from "@dnd-kit/core";
 import { ReactNode } from "react";
 
@@ -9,12 +10,13 @@ interface DroppableCalendarAreaProps {
 }
 // TODO: figure out how this looks and if I can reuse it
 export default function DroppableCalendarArea({ dayId, children }: DroppableCalendarAreaProps) {
+  const dropData: DropZoneData = {
+    dest: "calendar",
+    dayId,
+  };
   const { setNodeRef, isOver } = useDroppable({
     id: `droppable-${dayId}`,
-    data: {
-      type: "calendar",
-      dayId,
-    },
+    data: dropData,
   });
 
   return (

--- a/src/components/menuPlanning/MonthMealCard.tsx
+++ b/src/components/menuPlanning/MonthMealCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
+import { CATEGORY_TO_BUCKET, TAG_STYLES } from "@/lib/types";
+import type { RecipeNutritionOnly } from "@/lib/types";
+import type { CalendarDragData } from "@/app/menuPlanning/page";
+
+type MonthMealCardProps = {
+  item: RecipeNutritionOnly;
+  dayId: string;
+};
+
+type MonthMealCardPreviewProps = {
+  item: RecipeNutritionOnly;
+};
+
+export function MonthMealCardPreview({ item }: MonthMealCardPreviewProps) {
+  const tagClassName = TAG_STYLES[item.category];
+
+  return (
+    <div
+      className={`flex w-40 max-w-40 items-center gap-1.5 rounded-md px-2 py-1 font-montserrat text-sm shadow-lg ${tagClassName}`}
+    >
+      <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
+        {item.name}
+      </p>
+
+      <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+    </div>
+  );
+}
+
+export default function MonthMealCard({ item, dayId }: MonthMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
+
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
+
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: dndId,
+    data: dragData,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex max-w-full cursor-move items-center gap-1.5 rounded-md px-2 py-1 font-montserrat text-sm shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
+        isDragging ? "opacity-40" : ""
+      }`}
+      {...attributes}
+      {...listeners}
+    >
+      <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
+        {item.name}
+      </p>
+
+      <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/components/menuPlanning/MonthView.tsx
+++ b/src/components/menuPlanning/MonthView.tsx
@@ -1,6 +1,19 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import DroppableCalendarArea from "./DroppableCalendarArea";
+import MonthMealCard from "./MonthMealCard";
+import { RECIPE_BUCKETS } from "@/lib/types";
+import type { CalendarDay, NutrientDisplay, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
+
 const WEEKDAY_LABELS = ["SUN", "MON", "TUE", "WED", "THUR", "FRI", "SAT"] as const;
+
+type Props = {
+  /** In-month dates only (1..last day). */
+  monthDates: Date[];
+  dateToday: Date;
+  refetchTrigger?: number;
+};
 
 function isWeekend(d: Date): boolean {
   const day = d.getDay();
@@ -11,23 +24,102 @@ function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
 
-type Props = {
-  /** In-month dates only (1..last day). */
-  monthDates: Date[];
-  dateToday: Date;
-};
+function formatCalendarDayId(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
 
-export default function MonthView({ monthDates, dateToday }: Props) {
+  return `${year}${month}${day}`;
+}
+
+function mapCalendarDayToMeals(calendarDay: CalendarDay<RecipeNutritionOnly>): RecipeNutritionOnly[] {
+  return RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
+}
+
+function getVisibleMonthMeals(meals: RecipeNutritionOnly[]) {
+  if (meals.length <= 2) {
+    return {
+      visibleMeals: meals,
+      hiddenCount: 0,
+    };
+  }
+
+  return {
+    visibleMeals: meals.slice(0, 1),
+    hiddenCount: meals.length - 1,
+  };
+}
+
+export default function MonthView({ monthDates, dateToday, refetchTrigger }: Props) {
+  const [mealsByDayId, setMealsByDayId] = useState<Record<string, RecipeNutritionOnly[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+
   const focusDate = monthDates[0] ?? new Date();
+  const year = focusDate.getFullYear();
+  const month = String(focusDate.getMonth() + 1).padStart(2, "0");
+
   const leadingBlanks = focusDate.getDay(); // Sunday-first
-  const cells: Array<Date | null> = [...Array.from({ length: leadingBlanks }, () => null), ...monthDates];
+
+  const cells: Array<Date | null> = useMemo(
+    () => [...Array.from({ length: leadingBlanks }, () => null), ...monthDates],
+    [leadingBlanks, monthDates],
+  );
+
   const weeks: Array<Array<Date | null>> = [];
+
   for (let i = 0; i < cells.length; i += 7) {
     weeks.push(cells.slice(i, i + 7));
   }
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchMonthMeals() {
+      setIsLoading(true);
+
+      try {
+        const response = await fetch(`/api/calendar?year=${year}&month=${month}&populate=nutrition`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch calendar month ${year}-${month}`);
+        }
+
+        const calendarDays: CalendarDay<RecipeNutritionOnly>[] = await response.json();
+
+        const nextMealsByDayId = calendarDays.reduce<Record<string, RecipeNutritionOnly[]>>((acc, calendarDay) => {
+          acc[calendarDay._id] = mapCalendarDayToMeals(calendarDay);
+          return acc;
+        }, {});
+
+        if (!controller.signal.aborted) {
+          setMealsByDayId(nextMealsByDayId);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+
+        console.error("Error fetching month meals:", error);
+
+        if (!controller.signal.aborted) {
+          setMealsByDayId({});
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchMonthMeals();
+
+    return () => controller.abort();
+  }, [year, month, refetchTrigger]);
+
   return (
-    <div className="mt-4 flex min-h-0 w-full flex-1 flex-col gap-2">
+    <div className="mt-4 flex w-full flex-col gap-2">
       <div className="grid shrink-0 grid-cols-7 gap-2">
         {WEEKDAY_LABELS.map((label) => (
           <div key={label} className="text-center font-montserrat text-xs font-medium uppercase text-dark-gray">
@@ -43,13 +135,37 @@ export default function MonthView({ monthDates, dateToday }: Props) {
               if (!date) {
                 return <div key={`${wi}-${di}`} className="min-h-22.5" aria-hidden />;
               }
+
+              const dayId = formatCalendarDayId(date);
               const weekend = isWeekend(date);
               const isToday = date.toDateString() === dateToday.toDateString();
               const inMonth = isSameMonth(date, focusDate);
+              const meals = mealsByDayId[dayId] ?? [];
+              const { visibleMeals, hiddenCount } = getVisibleMonthMeals(meals);
+
+              const cellContent = (
+                <div className="flex min-h-22.5 flex-col items-start gap-1 p-2 pt-5">
+                  {isLoading ? (
+                    <p className="font-montserrat text-sm text-pepper/45">Loading...</p>
+                  ) : visibleMeals.length > 0 ? (
+                    <>
+                      {visibleMeals.map((meal) => (
+                        <MonthMealCard key={`${dayId}-${meal._id}`} item={meal} dayId={dayId} />
+                      ))}
+
+                      {hiddenCount > 0 ? (
+                        <div className="flex h-6 min-w-6 items-center justify-center rounded-md bg-jicama px-1.5 font-montserrat text-sm">
+                          +{hiddenCount}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : null}
+                </div>
+              );
 
               return (
                 <div
-                  key={`${wi}-${di}`}
+                  key={dayId}
                   className={`relative min-h-22.5 overflow-hidden rounded-xl border border-medium-gray ${
                     weekend ? "bg-medium-gray/35" : "bg-white"
                   } ${isToday ? "ring-2 ring-radish-900" : ""} ${inMonth ? "" : "opacity-60"}`}
@@ -57,9 +173,11 @@ export default function MonthView({ monthDates, dateToday }: Props) {
                   aria-disabled={weekend}
                   title={weekend ? "Weekends — meals cannot be placed here" : undefined}
                 >
-                  <span className="absolute right-2 top-2 font-montserrat text-sm font-normal text-dark-gray">
+                  <span className="absolute top-2 right-2 z-10 font-montserrat text-sm font-normal text-dark-gray">
                     {String(date.getDate()).padStart(2, "0")}
                   </span>
+
+                  {weekend ? cellContent : <DroppableCalendarArea dayId={dayId}>{cellContent}</DroppableCalendarArea>}
                 </div>
               );
             })}

--- a/src/components/menuPlanning/RecipeDatabase.tsx
+++ b/src/components/menuPlanning/RecipeDatabase.tsx
@@ -44,7 +44,7 @@ export default function RecipeDatabase({
   onPageChange,
 }: RecipeDatabaseProps) {
   return (
-    <div className="h-full p-6">
+    <div className="flex flex-col p-6 overflow-auto">
       <div className="mb-6 text-xl font-semibold">Recipe Database</div>
 
       <div className="flex flex-row items-center gap-4">
@@ -94,12 +94,11 @@ export default function RecipeDatabase({
       {loading && <div>Loading...</div>}
       {error && <div>{error}</div>}
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col min-h-0 gap-4 overflow-auto">
         {items.map((item) => (
           <DraggableRecipeCard key={item._id} item={item} />
         ))}
       </div>
-
       <div className="mt-4 flex justify-center">
         <PaginationDisplay
           currentPage={currentPage}

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -2,50 +2,35 @@
 
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
-import { RecipeBucket, RecipeCategory, TAG_STYLES } from "@/lib/types";
+import { CATEGORY_TO_BUCKET, TAG_STYLES, type Recipe, type RecipeBucket, type RecipeCategory } from "@/lib/types";
+import { ActiveDragData, CalendarDragData } from "@/app/menuPlanning/page";
 
-export type WeekMealCardData = {
-  _id: string;
-  name: string;
-  calories?: number;
-  servingSize?: string;
-  category: RecipeCategory;
-  calendarDayId: string;
-  calendarBucket: RecipeBucket;
+export type WeekMealCardProps = {
+  item: Recipe;
+  dayId: string;
 };
 
-type WeekMealCardProps = WeekMealCardData;
+export default function WeekMealCard({ item, dayId }: WeekMealCardProps) {
+  const bucket = CATEGORY_TO_BUCKET[item.category];
+  const dndId = `calendar-${dayId}-${bucket}-${item._id}`;
+  const tagClassName = TAG_STYLES[item.category];
 
-export default function WeekMealCard({
-  _id,
-  name,
-  calories,
-  servingSize,
-  category,
-  calendarDayId,
-  calendarBucket,
-}: WeekMealCardProps) {
-  const dndId = `calendar-${calendarDayId}-${calendarBucket}-${_id}`;
-  const tagClassName = TAG_STYLES[category];
-
+  const dragData: CalendarDragData = {
+    source: "calendar",
+    item,
+    dayId,
+  };
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: dndId,
-    data: {
-      type: "recipe",
-      source: "calendar",
-      itemType: "recipe",
-      recipeId: _id,
-      dayId: calendarDayId,
-      bucket: calendarBucket,
-      category,
-      recipeCategory: category,
-      name,
-      servingSize,
-    },
+    data: dragData,
   });
 
-  const caloriesText = calories != null ? `${calories} cal` : null;
-  const metaText = caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || servingSize;
+  const calories = item.nutritional_info.calories;
+  const servingSize = item.serving;
+
+  const caloriesText = calories ? `${calories} cal` : null;
+  const metaText =
+    caloriesText && servingSize ? `${caloriesText} / ${servingSize}` : caloriesText || `${servingSize} servings`;
 
   return (
     <div
@@ -57,8 +42,8 @@ export default function WeekMealCard({
       {...listeners}
     >
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[16px] leading-tight font-bold" title={name}>
-          {name}
+        <p className="truncate text-[16px] leading-tight font-bold" title={item.name}>
+          {item.name}
         </p>
 
         {metaText ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{metaText}</p> : null}

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import WeekMealCard, { type WeekMealCardData } from "./WeekMealCard";
+import WeekMealCard from "./WeekMealCard";
 import NutritionInfoNotMetCard from "./NutritionInfoNotMetCard";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 import { BUCKET_TO_CATEGORY, RECIPE_BUCKETS, Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
@@ -13,17 +13,13 @@ interface WeekViewProps {
 }
 
 type WeekViewDayData = {
-  meals: WeekMealCardData[];
+  meals: Recipe[];
   showNutritionInfoNotMet?: boolean;
-};
-
-type CalendarRecipe = Pick<Recipe, "_id" | "name" | "serving"> & {
-  nutritional_info?: Partial<Recipe["nutritional_info"]>;
 };
 
 type CalendarDayResponse = {
   _id: string;
-} & RecipeBuckets<CalendarRecipe>;
+} & RecipeBuckets<Recipe>;
 
 const EMPTY_DAY: WeekViewDayData = {
   meals: [],
@@ -38,29 +34,8 @@ function formatCalendarDayId(date: Date) {
   return `${year}${month}${day}`;
 }
 
-function mapCalendarRecipesToMeals(
-  recipes: CalendarRecipe[],
-  category: RecipeCategory,
-  calendarBucket: RecipeBucket,
-  calendarDayId: string,
-): WeekMealCardData[] {
-  return recipes.map((recipe) => ({
-    _id: recipe._id,
-    name: recipe.name,
-    calories: recipe.nutritional_info?.calories,
-    servingSize: recipe.serving != null ? `${recipe.serving}` : undefined,
-    category,
-    calendarBucket,
-    calendarDayId,
-  }));
-}
-
-function mapCalendarDayToMeals(calendarDay: CalendarDayResponse, fallbackDayId: string): WeekMealCardData[] {
-  const calendarDayId = calendarDay._id || fallbackDayId;
-
-  return RECIPE_BUCKETS.flatMap((bucket) =>
-    mapCalendarRecipesToMeals(calendarDay[bucket] ?? [], BUCKET_TO_CATEGORY[bucket], bucket, calendarDayId),
-  );
+function mapCalendarDayToMeals(calendarDay: CalendarDayResponse): Recipe[] {
+  return RECIPE_BUCKETS.flatMap((bucket) => calendarDay[bucket] ?? []);
 }
 
 async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promise<WeekViewDayData> {
@@ -80,7 +55,7 @@ async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promis
   const calendarDay: CalendarDayResponse = await response.json();
 
   return {
-    meals: mapCalendarDayToMeals(calendarDay, dayId),
+    meals: mapCalendarDayToMeals(calendarDay),
     showNutritionInfoNotMet: false,
   };
 }
@@ -155,9 +130,7 @@ export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekV
                     Loading meals...
                   </div>
                 ) : dayData.meals.length > 0 ? (
-                  dayData.meals.map((meal) => (
-                    <WeekMealCard key={`${meal.calendarDayId}-${meal.calendarBucket}-${meal._id}`} {...meal} />
-                  ))
+                  dayData.meals.map((meal) => <WeekMealCard key={`${dayId}-${meal._id}`} item={meal} dayId={dayId} />)
                 ) : (
                   <div className="flex flex-1 items-center justify-center text-center font-montserrat text-xs font-medium text-pepper/55">
                     Drop recipe here

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -7,6 +7,7 @@ type Params = {
   selectedCategories: Set<CategoryValue>;
   draftMode: boolean;
   sortBy?: SortOption;
+  pageSize?: number;
 };
 
 type Return = {
@@ -21,7 +22,6 @@ type Return = {
   refresh: () => void;
 };
 
-const PAGE_SIZE = 5;
 function appendSetParams(params: URLSearchParams, key: string, values?: Set<unknown>) {
   values?.forEach((value) => {
     params.append(key, String(value));
@@ -34,6 +34,7 @@ export function useMealData({
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
+  pageSize = 11,
 }: Params): Return {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [recipes, setRecipes] = useState<Recipe[]>([]);
@@ -75,7 +76,7 @@ export function useMealData({
         params.append("isDraft", draftMode ? "true" : "false");
         params.append("sortBy", sortBy);
         params.append("page", String(currentPage));
-        params.append("limit", String(draftMode ? PAGE_SIZE - 1 : PAGE_SIZE));
+        params.append("limit", String(draftMode ? pageSize - 1 : pageSize));
 
         if (trimmed) {
           params.append("name", trimmed);
@@ -163,6 +164,7 @@ export function useMealData({
     sortBy,
     refreshKey,
     isSubrecipeOnly,
+    pageSize,
   ]);
 
   const items = isComboMode ? combos : recipes;

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { CategoryValue, Combo, FilterSelections, Recipe, SortOption } from "@/lib/types";
 
+type ComboPopulate = "all" | "preview" | "nutrition" | "filters";
+
 type Params = {
   search: string;
   filters: FilterSelections;
@@ -8,10 +10,11 @@ type Params = {
   draftMode: boolean;
   sortBy?: SortOption;
   pageSize?: number;
+  comboPopulate?: ComboPopulate;
 };
 
-type Return = {
-  items: Recipe[] | Combo[];
+type Return<TComboRecipe = string> = {
+  items: Recipe[] | Combo<TComboRecipe>[]; // This hook can optionally populate the combos with the recipe data.
   loading: boolean;
   error: string | null;
   isComboMode: boolean;
@@ -28,17 +31,18 @@ function appendSetParams(params: URLSearchParams, key: string, values?: Set<unkn
   });
 }
 
-export function useMealData({
+export function useMealData<TComboRecipe = string>({
   search,
   filters,
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
   pageSize = 11,
-}: Params): Return {
+  comboPopulate,
+}: Params): Return<TComboRecipe> {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [combos, setCombos] = useState<Combo[]>([]);
+  const [combos, setCombos] = useState<Combo<TComboRecipe>[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [draftCount, setDraftCount] = useState(0);
@@ -86,6 +90,11 @@ export function useMealData({
         appendSetParams(params, "dietary", filters.dietary);
         appendSetParams(params, "exclusions", filters.exclusions);
         appendSetParams(params, "servings", filters.servings);
+
+        // Combo-only population parameter
+        if (isComboMode && comboPopulate) {
+          params.append("populate", comboPopulate);
+        }
 
         // Recipe-only filter.
         if (!isComboMode && isSubrecipeOnly) {
@@ -165,6 +174,7 @@ export function useMealData({
     refreshKey,
     isSubrecipeOnly,
     pageSize,
+    comboPopulate,
   ]);
 
   const items = isComboMode ? combos : recipes;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,6 +125,9 @@ export type RecipeMinimal = {
   name: string;
 };
 
+export type RecipeNutritionOnly = RecipePreview & { serving: number; nutritional_info: Nutrition };
+export type RecipeFiltersOnly = RecipePreview & MealFilterFields;
+
 // Takes the type of the recipe buckets.
 // By default should be string IDs, but can request Recipe or RecipePreviews from the API as well.
 // TODO: add a "populate" parameter to the combo schema that will also preview the recipes
@@ -146,9 +149,9 @@ export type Combo<T = string> = {
 /* Calendar and date types                                                    */
 /* -------------------------------------------------------------------------- */
 
-export type CalendarDay = {
+export type CalendarDay<T = Recipe> = {
   _id: string; // YYYYMMDD
-} & RecipeBuckets<Recipe>;
+} & RecipeBuckets<T>;
 
 export const MONTHS = [
   "January",


### PR DESCRIPTION
## Developer: Kevin Diaz

Closes #160 

### Pull Request Summary

Adds Monthly menu planning drag and drop support, fixes menu planning page layout (scrolling behavior), adds permissions page pagination (but we don't have an API for fetching the permissions yet... so it is client side).

also fixes an issue with the recipes page where it does a million fetches just to get the recipes in a combo. New the API just returns the full recipes with the combo if you ask nicely.

### Modifications

- `src/app/api/calendar/[id]/route.ts`: Now returns a fully populated list of recipes for the day. Previously had to re-fetch if the actual recipe data was needed.
- `src/app/api/calendar/route.ts`: Can now choose to what degree to populate the returned list of calendar days (either preview the recipes, populate the nutrition only, the filters only, or everything). Will be useful for aggregating nutrition data for displaying warnings and such.
- `src/app/menuPlanning/page.tsx`: added the drag and drop logic to the monthly view, and trash logic to the daily view.
- `src/components/menuPlanning/DayView.tsx`: made the cards draggable to support dragging to trash. (Only the grip icon triggers the drag, because otherwise clicking the trashcan would also trigger a drag.)
- `src/components/menuPlanning/DraggableRecipeCard.tsx`: Cleaned up types
- `src/components/menuPlanning/DroppableCalendarArea.tsx`: cleaned up types
- `src/components/menuPlanning/MonthMealCard.tsx`: card that is displayed on the monthly menu planning
- `src/components/menuPlanning/MonthView.tsx`: now properly fetches data and supports drag and drop
- `src/components/menuPlanning/RecipeDatabase.tsx`: fixed scroll logic.
- `src/components/menuPlanning/WeekMealCard.tsx`: cleaned up types
- `src/components/menuPlanning/WeekView.tsx`: cleaned up types
- `src/components/CategoryToggle.tsx`: refactored into pill toggle helper component for reusability
- `src/components/PermissionsClient.tsx`: pagination
- `src/components/PillToggle.tsx`: like category toggle, but can be used with other things (like permissions page)
- `src/hooks/useMealData.ts`: now takes page size as an argument to allow recipe page to display more recipes.
- `src/lib/types.ts`: added useful types for calendar data.

### Testing Considerations

checked dragging and dropping recipes, trashing recipes, etc.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1316" height="737" alt="image" src="https://github.com/user-attachments/assets/8240b8e1-72b0-442f-bc36-7ef54f57da1f" />
<img width="558" height="240" alt="image" src="https://github.com/user-attachments/assets/b519ea6a-eed6-4522-8d73-31da14e7820e" />
<img width="1130" height="476" alt="image" src="https://github.com/user-attachments/assets/af98a119-ed5e-4a7f-be12-f3824fccc54e" />
<img width="1893" height="312" alt="image" src="https://github.com/user-attachments/assets/6f4dc753-ce41-44ba-826f-b4b66bebd830" />


