### PR TITLE
161: Menu Management

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import connectDB from "@/database/db";
+import "@/database/RecipeSchema";
 import Calendar from "@/database/CalendarSchema";
 import { RECIPE_BUCKETS } from "@/lib/types";
 

--- a/src/app/menuPlanning/page.tsx
+++ b/src/app/menuPlanning/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { ReactNode } from "react";
 import { DndContext, DragEndEvent, DragStartEvent, DragOverlay, useDroppable } from "@dnd-kit/core";
 import WeekView from "@/components/menuPlanning/WeekView";
@@ -31,8 +31,6 @@ import xlsx, { IContent, IJsonSheet } from "json-as-xlsx";
 import { toggleCategory } from "@/lib/helpers";
 import DailyNutritionSummary from "@/components/menuPlanning/DailyNutritionSummary";
 import { MonthMealCardPreview } from "@/components/menuPlanning/MonthMealCard";
-
-const today = new Date();
 
 // Dummy per-day nutrition totals for the week (Mon–Fri), mocking backend data
 const DUMMY_WEEKLY_NUTRITION: Nutrition[] = [
@@ -171,10 +169,13 @@ const getCurrentViewDates = (today: Date, view: "Month" | "Week" | "Day") => {
 };
 
 export default function MenuPlanning() {
+  const [planningRoot] = useState(() => new Date());
+  const dateToday = new Date();
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("createdDate");
   const [calendarView, setCalendarView] = useState<"Month" | "Week" | "Day">("Week");
   const [datesOffset, setDatesOffset] = useState(0);
+  const [pickedDateFromMonth, setPickedDateFromMonth] = useState<Date | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<Set<CategoryValue>>(new Set<CategoryValue>(["Combo"]));
   const [filters, setFilters] = useState(() => createEmptyFilterSelections());
 
@@ -182,15 +183,46 @@ export default function MenuPlanning() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [activeDragData, setActiveDragData] = useState<ActiveDragData | null>(null);
 
-  useEffect(() => {
-    setDatesOffset(0);
-  }, [calendarView]);
+  const previousCalendarView = useRef(calendarView);
 
-  // Day: 1 day, Week: 5 days, Month: 35 days (including prev/next month)
-  const viewDates = getCurrentViewDates(getOffsetDate(today, datesOffset, calendarView), calendarView);
+  useEffect(() => {
+    const prev = previousCalendarView.current;
+    previousCalendarView.current = calendarView;
+
+    if (calendarView === "Month" && prev !== "Month" && pickedDateFromMonth) {
+      const p = pickedDateFromMonth;
+      const monthDiff = (p.getFullYear() - planningRoot.getFullYear()) * 12 + (p.getMonth() - planningRoot.getMonth());
+      setDatesOffset(monthDiff);
+      return;
+    }
+
+    if (prev !== calendarView) {
+      setDatesOffset(0);
+    }
+  }, [calendarView, pickedDateFromMonth, planningRoot]);
+
+  const offsetAnchor = getOffsetDate(planningRoot, datesOffset, calendarView);
+  const monthAnchor = getOffsetDate(planningRoot, datesOffset, "Month");
+  const weekDayAnchor =
+    (calendarView === "Week" || calendarView === "Day") && pickedDateFromMonth ? pickedDateFromMonth : offsetAnchor;
+
+  const viewDates =
+    calendarView === "Month"
+      ? getCurrentViewDates(monthAnchor, "Month")
+      : getCurrentViewDates(weekDayAnchor, calendarView);
+
+  const bumpDatesOffset = (delta: number) => {
+    setPickedDateFromMonth(null);
+    setDatesOffset((d) => d + delta);
+  };
+
+  const resetToPlanningToday = () => {
+    setPickedDateFromMonth(null);
+    setDatesOffset(0);
+  };
 
   const downloadMonthlyMenu = async () => {
-    const baseDate = calendarView === "Month" ? viewDates[10] : viewDates[0];
+    const baseDate = viewDates[0] ?? planningRoot;
     const currentMonth = baseDate.getMonth();
     const currentYear = baseDate.getFullYear();
 
@@ -431,9 +463,9 @@ export default function MenuPlanning() {
           <div className="flex w-260 flex-col">
             <div className="flex items-center justify-between">
               <div className="flex items-center justify-center gap-2">
-                <CurrentDateButton onClick={() => setDatesOffset(0)} />
+                <CurrentDateButton onClick={resetToPlanningToday} />
 
-                <button className="cursor-pointer" onClick={() => setDatesOffset(datesOffset - 1)}>
+                <button type="button" className="cursor-pointer" onClick={() => bumpDatesOffset(-1)}>
                   <ChevronLeft size={20} strokeWidth={2.5} />
                 </button>
 
@@ -456,7 +488,7 @@ export default function MenuPlanning() {
                     })}
                 </span>
 
-                <button className="cursor-pointer" onClick={() => setDatesOffset(datesOffset + 1)}>
+                <button type="button" className="cursor-pointer" onClick={() => bumpDatesOffset(1)}>
                   <ChevronRight size={20} strokeWidth={2.5} />
                 </button>
               </div>
@@ -467,12 +499,14 @@ export default function MenuPlanning() {
                     className={`cursor-pointer rounded-md px-4 py-1 font-semibold text-black ${
                       calendarView === "Month" ? "bg-radish-900 text-white" : ""
                     }`}
+                    type="button"
                     onClick={() => setCalendarView("Month")}
                   >
                     Month
                   </button>
 
                   <button
+                    type="button"
                     className={`cursor-pointer rounded-md px-4 py-1 font-semibold ${
                       calendarView === "Week" ? "bg-radish-900 text-white" : "text-black"
                     }`}
@@ -482,6 +516,7 @@ export default function MenuPlanning() {
                   </button>
 
                   <button
+                    type="button"
                     className={`cursor-pointer rounded-md px-4 py-1 font-semibold text-black ${
                       calendarView === "Day" ? "bg-radish-900 text-white" : ""
                     }`}
@@ -505,7 +540,13 @@ export default function MenuPlanning() {
 
             {calendarView === "Month" && (
               <>
-                <MonthView monthDates={viewDates} dateToday={today} refetchTrigger={recipeDropTrigger} />
+                <MonthView
+                  monthDates={viewDates}
+                  dateToday={dateToday}
+                  refetchTrigger={recipeDropTrigger}
+                  selectedDate={pickedDateFromMonth}
+                  onDaySelect={setPickedDateFromMonth}
+                />
 
                 <div className="mt-2">
                   <WarningQuotaMonthly />
@@ -519,7 +560,12 @@ export default function MenuPlanning() {
 
             {calendarView === "Week" && (
               <>
-                <WeekView dateToday={today} weekDates={viewDates} refetchTrigger={recipeDropTrigger} />
+                <WeekView
+                  dateToday={dateToday}
+                  weekDates={viewDates}
+                  refetchTrigger={recipeDropTrigger}
+                  selectedDate={pickedDateFromMonth}
+                />
 
                 <div className="mt-auto flex justify-end pb-4">
                   <TrashDropZone />

--- a/src/components/menuPlanning/DayView.tsx
+++ b/src/components/menuPlanning/DayView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import DroppableCalendarArea from "./DroppableCalendarArea";
+import RecipeSeeMorePopover from "./RecipeSeeMorePopover";
 import { CATEGORY_TO_BUCKET, RECIPE_BUCKETS, TAG_STYLES } from "@/lib/types";
 import type { Recipe, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
 import type { CalendarDragData } from "@/app/menuPlanning/page";
@@ -93,16 +94,18 @@ function DayMealCard({ item, dayId, deletingId, onDelete }: DayMealCardProps) {
   return (
     <div
       ref={setNodeRef}
-      className={`flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md ${
+      className={`group flex items-center gap-4 rounded-xl border-2 border-gray-300 bg-white px-5 py-4 transition hover:shadow-md ${
         isDragging ? "opacity-40" : ""
       }`}
     >
-      <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <h3 className="truncate font-montserrat text-xl font-bold" title={item.name}>
           {item.name}
         </h3>
 
         {metaText ? <p className="font-montserrat text-base font-medium text-pepper/70">{metaText}</p> : null}
+
+        <RecipeSeeMorePopover recipeId={item._id} variant="default" />
       </div>
 
       <span className={`shrink-0 rounded-md px-3 py-1.5 font-montserrat text-base font-medium ${tagClassName}`}>

--- a/src/components/menuPlanning/MonthMealCard.tsx
+++ b/src/components/menuPlanning/MonthMealCard.tsx
@@ -5,6 +5,7 @@ import { useDraggable } from "@dnd-kit/core";
 import { CATEGORY_TO_BUCKET, TAG_STYLES } from "@/lib/types";
 import type { RecipeNutritionOnly } from "@/lib/types";
 import type { CalendarDragData } from "@/app/menuPlanning/page";
+import RecipeSeeMorePopover from "./RecipeSeeMorePopover";
 
 type MonthMealCardProps = {
   item: RecipeNutritionOnly;
@@ -50,17 +51,21 @@ export default function MonthMealCard({ item, dayId }: MonthMealCardProps) {
   return (
     <div
       ref={setNodeRef}
-      className={`flex max-w-full cursor-move items-center gap-1.5 rounded-md px-2 py-1 font-montserrat text-sm shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
+      className={`group flex max-w-full cursor-move flex-col gap-0.5 rounded-md px-2 py-1.5 font-montserrat text-sm shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
         isDragging ? "opacity-40" : ""
       }`}
       {...attributes}
       {...listeners}
     >
-      <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
-        {item.name}
-      </p>
+      <div className="flex min-w-0 items-center gap-1">
+        <p className="min-w-0 flex-1 truncate leading-tight" title={item.name}>
+          {item.name}
+        </p>
 
-      <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+        <GripVertical className="h-3.5 w-3.5 shrink-0 text-current opacity-90" aria-hidden="true" />
+      </div>
+
+      <RecipeSeeMorePopover recipeId={item._id} variant="compact" />
     </div>
   );
 }

--- a/src/components/menuPlanning/MonthView.tsx
+++ b/src/components/menuPlanning/MonthView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import DroppableCalendarArea from "./DroppableCalendarArea";
 import MonthMealCard from "./MonthMealCard";
 import { RECIPE_BUCKETS } from "@/lib/types";
-import type { CalendarDay, NutrientDisplay, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
+import type { CalendarDay, RecipeBuckets, RecipeNutritionOnly } from "@/lib/types";
 
 const WEEKDAY_LABELS = ["SUN", "MON", "TUE", "WED", "THUR", "FRI", "SAT"] as const;
 
@@ -13,6 +13,9 @@ type Props = {
   monthDates: Date[];
   dateToday: Date;
   refetchTrigger?: number;
+  /** Calendar day picked in month view; used when switching to week/day on the parent. */
+  selectedDate: Date | null;
+  onDaySelect: (date: Date) => void;
 };
 
 function isWeekend(d: Date): boolean {
@@ -22,6 +25,10 @@ function isWeekend(d: Date): boolean {
 
 function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
 function formatCalendarDayId(date: Date) {
@@ -50,7 +57,7 @@ function getVisibleMonthMeals(meals: RecipeNutritionOnly[]) {
   };
 }
 
-export default function MonthView({ monthDates, dateToday, refetchTrigger }: Props) {
+export default function MonthView({ monthDates, dateToday, refetchTrigger, selectedDate, onDaySelect }: Props) {
   const [mealsByDayId, setMealsByDayId] = useState<Record<string, RecipeNutritionOnly[]>>({});
   const [isLoading, setIsLoading] = useState(true);
 
@@ -140,6 +147,7 @@ export default function MonthView({ monthDates, dateToday, refetchTrigger }: Pro
               const weekend = isWeekend(date);
               const isToday = date.toDateString() === dateToday.toDateString();
               const inMonth = isSameMonth(date, focusDate);
+              const isDaySelected = selectedDate ? isSameCalendarDay(date, selectedDate) : false;
               const meals = mealsByDayId[dayId] ?? [];
               const { visibleMeals, hiddenCount } = getVisibleMonthMeals(meals);
 
@@ -163,15 +171,34 @@ export default function MonthView({ monthDates, dateToday, refetchTrigger }: Pro
                 </div>
               );
 
+              const selectDay = () => {
+                onDaySelect(new Date(date.getFullYear(), date.getMonth(), date.getDate()));
+              };
+
               return (
                 <div
                   key={dayId}
-                  className={`relative min-h-22.5 overflow-hidden rounded-xl border border-medium-gray ${
+                  role="button"
+                  tabIndex={0}
+                  onClick={selectDay}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      selectDay();
+                    }
+                  }}
+                  className={`relative min-h-22.5 overflow-visible rounded-xl border border-medium-gray ${
                     weekend ? "bg-medium-gray/35" : "bg-white"
-                  } ${isToday ? "ring-2 ring-radish-900" : ""} ${inMonth ? "" : "opacity-60"}`}
+                  } ${isToday ? "ring-2 ring-radish-900" : ""} ${isDaySelected && !isToday ? "ring-2 ring-radish-600/80" : ""} ${
+                    isDaySelected && isToday ? "ring-2 ring-radish-900 ring-offset-2 ring-offset-gray-100" : ""
+                  } ${inMonth ? "" : "opacity-60"} cursor-pointer`}
                   data-drop-disabled={weekend ? "true" : undefined}
-                  aria-disabled={weekend}
-                  title={weekend ? "Weekends — meals cannot be placed here" : undefined}
+                  aria-pressed={isDaySelected}
+                  title={
+                    weekend
+                      ? "Weekends — meals cannot be placed here. Click to select this day."
+                      : "Click to select this day"
+                  }
                 >
                   <span className="absolute top-2 right-2 z-10 font-montserrat text-sm font-normal text-dark-gray">
                     {String(date.getDate()).padStart(2, "0")}

--- a/src/components/menuPlanning/MonthView.tsx
+++ b/src/components/menuPlanning/MonthView.tsx
@@ -172,33 +172,36 @@ export default function MonthView({ monthDates, dateToday, refetchTrigger, selec
               );
 
               const selectDay = () => {
+                if (weekend) return;
                 onDaySelect(new Date(date.getFullYear(), date.getMonth(), date.getDate()));
               };
 
               return (
                 <div
                   key={dayId}
-                  role="button"
-                  tabIndex={0}
-                  onClick={selectDay}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      selectDay();
-                    }
-                  }}
+                  role={weekend ? undefined : "button"}
+                  tabIndex={weekend ? undefined : 0}
+                  onClick={weekend ? undefined : selectDay}
+                  onKeyDown={
+                    weekend
+                      ? undefined
+                      : (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            selectDay();
+                          }
+                        }
+                  }
                   className={`relative min-h-22.5 overflow-visible rounded-xl border border-medium-gray ${
                     weekend ? "bg-medium-gray/35" : "bg-white"
                   } ${isToday ? "ring-2 ring-radish-900" : ""} ${isDaySelected && !isToday ? "ring-2 ring-radish-600/80" : ""} ${
                     isDaySelected && isToday ? "ring-2 ring-radish-900 ring-offset-2 ring-offset-gray-100" : ""
-                  } ${inMonth ? "" : "opacity-60"} cursor-pointer`}
+                  } ${inMonth ? "" : "opacity-60"} ${
+                    weekend ? "pointer-events-none cursor-default select-none" : "cursor-pointer"
+                  }`}
                   data-drop-disabled={weekend ? "true" : undefined}
-                  aria-pressed={isDaySelected}
-                  title={
-                    weekend
-                      ? "Weekends — meals cannot be placed here. Click to select this day."
-                      : "Click to select this day"
-                  }
+                  aria-pressed={weekend ? undefined : isDaySelected}
+                  title={weekend ? "Weekends — not available for planning or selection." : "Click to select this day"}
                 >
                   <span className="absolute top-2 right-2 z-10 font-montserrat text-sm font-normal text-dark-gray">
                     {String(date.getDate()).padStart(2, "0")}

--- a/src/components/menuPlanning/RecipeSeeMorePopover.tsx
+++ b/src/components/menuPlanning/RecipeSeeMorePopover.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+
+type RecipeSeeMorePopoverProps = {
+  recipeId: string;
+  /** Tighter row for month cells */
+  variant?: "compact" | "default";
+};
+
+/**
+ * “See More” sits in normal layout at the bottom of the recipe card (not floating above it).
+ * Shown when the card (`group`) is hovered so the cursor never leaves the hover region to click.
+ * Opens `/recipe?id=` in a new tab (RecipePageClient).
+ */
+export default function RecipeSeeMorePopover({ recipeId, variant = "default" }: RecipeSeeMorePopoverProps) {
+  const href = `/recipe?id=${encodeURIComponent(recipeId)}`;
+  const textSize = variant === "compact" ? "text-[11px]" : "text-xs";
+  const iconSize = variant === "compact" ? "h-3 w-3" : "h-3.5 w-3.5";
+  const rowMin = variant === "compact" ? "min-h-[1.125rem]" : "min-h-[1.375rem]";
+
+  return (
+    <div className={`shrink-0 ${rowMin} pt-0.5`}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`pointer-events-none inline-flex w-fit max-w-full items-center gap-0.5 font-montserrat font-semibold text-current opacity-0 underline decoration-current/40 underline-offset-2 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 hover:decoration-current ${textSize}`}
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        aria-label="See More: open recipe in new tab"
+      >
+        See More
+        <ArrowUpRight className={`${iconSize} shrink-0`} strokeWidth={2.2} aria-hidden />
+      </a>
+    </div>
+  );
+}

--- a/src/components/menuPlanning/WeekMealCard.tsx
+++ b/src/components/menuPlanning/WeekMealCard.tsx
@@ -2,8 +2,9 @@
 
 import { GripVertical } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
-import { CATEGORY_TO_BUCKET, TAG_STYLES, type Recipe, type RecipeBucket, type RecipeCategory } from "@/lib/types";
-import { ActiveDragData, CalendarDragData } from "@/app/menuPlanning/page";
+import { CATEGORY_TO_BUCKET, TAG_STYLES, type Recipe } from "@/lib/types";
+import type { CalendarDragData } from "@/app/menuPlanning/page";
+import RecipeSeeMorePopover from "./RecipeSeeMorePopover";
 
 export type WeekMealCardProps = {
   item: Recipe;
@@ -35,21 +36,23 @@ export default function WeekMealCard({ item, dayId }: WeekMealCardProps) {
   return (
     <div
       ref={setNodeRef}
-      className={`flex cursor-move items-center gap-3 rounded-md px-4 py-3 font-montserrat shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
+      className={`group flex cursor-move items-stretch gap-3 rounded-md px-4 py-3 font-montserrat shadow-[0_2px_6px_rgba(72,73,75,0.08)] ${tagClassName} ${
         isDragging ? "opacity-40" : ""
       }`}
       {...attributes}
       {...listeners}
     >
-      <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <p className="truncate text-[16px] leading-tight font-bold" title={item.name}>
           {item.name}
         </p>
 
-        {metaText ? <p className="mt-1 truncate text-[15px] leading-tight font-medium">{metaText}</p> : null}
+        {metaText ? <p className="truncate text-[15px] leading-tight font-medium">{metaText}</p> : null}
+
+        <RecipeSeeMorePopover recipeId={item._id} variant="default" />
       </div>
 
-      <GripVertical className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden="true" />
+      <GripVertical className="h-5 w-5 shrink-0 self-center text-current opacity-90" aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/menuPlanning/WeekView.tsx
+++ b/src/components/menuPlanning/WeekView.tsx
@@ -4,12 +4,17 @@ import { useEffect, useState } from "react";
 import WeekMealCard from "./WeekMealCard";
 import NutritionInfoNotMetCard from "./NutritionInfoNotMetCard";
 import DroppableCalendarArea from "./DroppableCalendarArea";
-import { BUCKET_TO_CATEGORY, RECIPE_BUCKETS, Recipe, RecipeBucket, RecipeBuckets, RecipeCategory } from "@/lib/types";
+import { RECIPE_BUCKETS, Recipe, RecipeBuckets } from "@/lib/types";
 
 interface WeekViewProps {
   dateToday: Date;
   weekDates: Date[];
   refetchTrigger?: number;
+  selectedDate: Date | null;
+}
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
 type WeekViewDayData = {
@@ -60,7 +65,7 @@ async function fetchCalendarDayMeals(dayId: string, signal: AbortSignal): Promis
   };
 }
 
-export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekViewProps) {
+export default function WeekView({ dateToday, weekDates, refetchTrigger, selectedDate }: WeekViewProps) {
   const [weekViewMeals, setWeekViewMeals] = useState<WeekViewDayData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -108,6 +113,7 @@ export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekV
         const dayId = weekDayIds[index] ?? formatCalendarDayId(date);
         const dayData = weekViewMeals[index] ?? EMPTY_DAY;
         const isToday = date.toDateString() === dateToday.toDateString();
+        const isDaySelected = selectedDate ? isSameCalendarDay(date, selectedDate) : false;
 
         return (
           <div key={dayId} className="flex min-w-0 flex-col items-center">
@@ -122,7 +128,9 @@ export default function WeekView({ dateToday, weekDates, refetchTrigger }: WeekV
             <div
               className={`flex min-h-105 w-full flex-1 flex-col gap-3 rounded-[14px] p-3 ${
                 isToday ? "border-2 border-radish-900" : "border border-medium-gray/35"
-              } bg-white`}
+              } bg-white ${isDaySelected && !isToday ? "ring-2 ring-radish-600/80 ring-offset-2 ring-offset-gray-100" : ""} ${
+                isDaySelected && isToday ? "ring-2 ring-radish-900 ring-offset-2 ring-offset-gray-100" : ""
+              }`}
             >
               <DroppableCalendarArea dayId={dayId}>
                 {isLoading ? (


### PR DESCRIPTION
## Developer: Srinithi Doddapaneni

Closes #161 

### Pull Request Summary
Create a See More component which takes users to the appropiate Recipe Card in the recipes page
Allow users to click on various days in monthly view which update weekly and daily view accordingly

### Modifications
route.ts --> added import so monthly view correctly imports recipes from database
WeekView --> highlights the new day selected and changes week accordingly
MonthView --> implementation of selecting another day OTHER than weekends
DayView --> implement see more
components/RecipeSeeMorePopover --> implement lucide icon that when clicked takes users to recipe card
MonthMealCard --> implement see more
WeekMealCard --> implement see more 
page.tsx --> updated for offsets

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="1467" height="923" alt="Screenshot 2026-05-11 at 5 03 29 PM" src="https://github.com/user-attachments/assets/3935eb1e-9207-4e73-bc0c-0bd1da9815e8" />
<img width="1470" height="842" alt="Screenshot 2026-05-11 at 5 03 44 PM" src="https://github.com/user-attachments/assets/39ac4ea3-2d8f-4407-aa16-0fd39a70bbf9" />
<img width="1470" height="551" alt="Screenshot 2026-05-11 at 5 04 00 PM" src="https://github.com/user-attachments/assets/bccc3190-fb5f-4083-85ec-0b85bcfdfc65" />
<img width="1452" height="919" alt="Screenshot 2026-05-11 at 5 04 18 PM" src="https://github.com/user-attachments/assets/59eacca4-4591-4ff3-918a-c484522ddd0d" />

