### PR TITLE
Fixing Recipe Bugs

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -36,7 +36,7 @@ export default function CardGrid({
 
   if (isComboMode) {
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 grid-rows-2 gap-3 md:gap-6 w-full">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6 w-full overflow-y-auto">
         {!draftMode && <DraftEntryCard variant="Combo" numDrafts={draftCount} />}
 
         {(items as Combo<RecipePreview>[]).map((combo) => (

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -36,7 +36,7 @@ export default function CardGrid({
 
   if (isComboMode) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6 w-full">
+      <div className="grid grid-cols-1 md:grid-cols-2 grid-rows-2 gap-3 md:gap-6 w-full">
         {!draftMode && <DraftEntryCard variant="Combo" numDrafts={draftCount} />}
 
         {(items as Combo<RecipePreview>[]).map((combo) => (
@@ -55,7 +55,7 @@ export default function CardGrid({
   // ---------------- Recipe Layout ----------------
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4 w-full">
+    <div className="grid grid-cols-1 md:grid-cols-2 md:grid-rows-2 gap-3 md:gap-4 w-full overflow-hidden">
       {!draftMode && <DraftEntryCard variant="recipe" numDrafts={draftCount} />}
 
       {(items as Recipe[]).map((recipe) => (

--- a/src/components/CreateRecipePopUp.tsx
+++ b/src/components/CreateRecipePopUp.tsx
@@ -166,8 +166,13 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
   const handleQuantityChange = (index: number, value: string) => {
     const updated = [...ingredientInputs];
 
-    // convert to number
-    updated[index].quantity = value === "" ? "" : Number(value);
+    if (value === "") {
+      updated[index].quantity = "";
+    } else {
+      const numValue = Number(value);
+      // convert to number
+      updated[index].quantity = Math.max(0, numValue);
+    }
 
     setIngredientInputs(updated);
   };
@@ -854,6 +859,7 @@ export default function CreateRecipePopUp({ item, open, onClose, recipeType, edi
 
                           <input
                             type="number"
+                            min="0"
                             placeholder="Enter Number"
                             value={item.quantity}
                             onChange={(e) => handleQuantityChange(index, e.target.value)}

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -11,6 +11,8 @@ import {
   FilterSelections,
 } from "@/lib/types";
 
+const ITEMS_PER_PAGE = 4;
+
 type FilterMenuProps = {
   onFilterChange?: (selections: FilterSelections) => void;
   /** Seed overlay draft from parent-applied filters when opening the sheet. */

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -11,8 +11,6 @@ import {
   FilterSelections,
 } from "@/lib/types";
 
-const ITEMS_PER_PAGE = 4;
-
 type FilterMenuProps = {
   onFilterChange?: (selections: FilterSelections) => void;
   /** Seed overlay draft from parent-applied filters when opening the sheet. */
@@ -126,7 +124,7 @@ export default function FilterMenu({ onFilterChange, initialSelections, mobileOv
       )}
 
       <div className={mobileOverlay ? "flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-2 pt-3" : "flex flex-col"}>
-        {FILTER_SECTIONS.map((section) => (
+        {FILTER_SECTIONS.filter((section) => section.id !== "servings").map((section) => (
           <FilterMenuOption
             key={section.id}
             label={section.label}

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -52,7 +52,7 @@ export default function MealBrowser({
   onOpenItem,
 }: Props) {
   return (
-    <div className="flex flex-1 flex-col gap-3 md:gap-4">
+    <div className="flex flex-1 flex-col gap-3 md:gap-4 md:gap-4 h-[calc(100vh-120px)] min-h-0 overflow-hidden">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-5">
         {topLeftChildren}
 
@@ -99,7 +99,7 @@ export default function MealBrowser({
         </div>
       </div>
 
-      <div className="w-full h-full overflow-visible md:overflow-hidden pb-5">
+      <div className={`w-full flex-1 min-h-0 ${isComboMode ? "overflow-y-auto pb-16" : "overflow-hidden pb-5"}`}>
         <CardGrid
           loading={loading}
           error={error}

--- a/src/components/MealBrowser.tsx
+++ b/src/components/MealBrowser.tsx
@@ -99,7 +99,7 @@ export default function MealBrowser({
         </div>
       </div>
 
-      <div className="w-full overflow-auto pb-5">
+      <div className="w-full h-full overflow-visible md:overflow-hidden pb-5">
         <CardGrid
           loading={loading}
           error={error}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -39,7 +39,7 @@ export default function RecipeCard({ item, isSelected, onSelect, onOpen }: Recip
       </div>
 
       <span
-        className={`w-16 shrink-0 rounded-md px-2 py-1 text-center font-montserrat text-xs font-medium md:w-20 md:px-3 md:py-1.5 md:text-base ${tagStyle}`}
+        className={`shrink-0 rounded-md px-2 py-1 text-center font-montserrat text-xs font-medium md:px-3 md:py-1.5 md:text-base ${tagStyle}`}
       >
         {item.category}
       </span>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -15,7 +15,7 @@ export default function RecipeCard({ item, isSelected, onSelect, onOpen }: Recip
   const [editMode, setEditMode] = useState(false);
 
   const tagStyle = TAG_STYLES[item.category];
-  const metaText = `${item.nutritional_info.calories} cal / ${item.serving}`;
+  const metaText = `${item.nutritional_info.calories} cal / ${item.serving} ${item.serving > 1 ? "servings" : "serving"}`;
 
   return (
     <div

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -81,7 +81,6 @@ export default function RecipePageClient() {
       selectedCategories,
       draftMode: false,
       comboPopulate: "preview",
-      pageSize: pageSize,
     });
 
   const handleOpenItem = async (item: BrowserItem) => {

--- a/src/components/RecipePageClient.tsx
+++ b/src/components/RecipePageClient.tsx
@@ -38,6 +38,21 @@ export default function RecipePageClient() {
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [activeType, setActiveType] = useState<CategoryDisplayType | null>(null);
+  const [pageSize, setPageSize] = useState(4);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setPageSize(11);
+      } else {
+        setPageSize(4);
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   async function getRecipe(id: string): Promise<Recipe> {
     const res = await fetch(`/api/recipes/${id}`);
@@ -66,6 +81,7 @@ export default function RecipePageClient() {
       selectedCategories,
       draftMode: false,
       comboPopulate: "preview",
+      pageSize: pageSize,
     });
 
   const handleOpenItem = async (item: BrowserItem) => {
@@ -107,7 +123,7 @@ export default function RecipePageClient() {
   const selectedItemIsCombo = selectedItem ? !isRecipe(selectedItem) : isComboMode;
 
   return (
-    <main className="relative flex min-h-0 flex-1 flex-col gap-6 overflow-hidden px-5 pt-5 md:flex-row">
+    <main className="relative flex min-h-0 flex-1 flex-col gap-6 overflow-auto md:overflow-hidden px-5 pt-5 md:flex-row">
       <MealBrowser
         setSearch={setSearch}
         items={items}

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -37,7 +37,7 @@ export function useMealData<TComboRecipe = string>({
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
-  pageSize = 11,
+  pageSize = 4,
   comboPopulate,
 }: Params): Return<TComboRecipe> {
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -80,7 +80,9 @@ export function useMealData<TComboRecipe = string>({
         params.append("isDraft", draftMode ? "true" : "false");
         params.append("sortBy", sortBy);
         params.append("page", String(currentPage));
-        params.append("limit", String(draftMode ? pageSize - 1 : pageSize));
+
+        const limit = !draftMode ? pageSize - 1 : pageSize;
+        params.append("limit", String(limit));
 
         if (trimmed) {
           params.append("name", trimmed);

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -9,7 +9,6 @@ type Params = {
   selectedCategories: Set<CategoryValue>;
   draftMode: boolean;
   sortBy?: SortOption;
-  pageSize?: number;
   comboPopulate?: ComboPopulate;
 };
 
@@ -37,7 +36,6 @@ export function useMealData<TComboRecipe = string>({
   selectedCategories,
   draftMode,
   sortBy = "createdDate",
-  pageSize = 4,
   comboPopulate,
 }: Params): Return<TComboRecipe> {
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -54,6 +52,8 @@ export function useMealData<TComboRecipe = string>({
 
   const isComboMode = selectedCategories.has("Combo");
   const isSubrecipeOnly = filters.additional?.has("isSubrecipe") ?? false;
+
+  const pageSize = isComboMode ? 6 : 4;
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 250);
@@ -91,7 +91,6 @@ export function useMealData<TComboRecipe = string>({
         appendSetParams(params, "proteinSources", filters.proteinSources);
         appendSetParams(params, "dietary", filters.dietary);
         appendSetParams(params, "exclusions", filters.exclusions);
-        appendSetParams(params, "servings", filters.servings);
 
         // Combo-only population parameter
         if (isComboMode && comboPopulate) {

--- a/src/hooks/useMealData.ts
+++ b/src/hooks/useMealData.ts
@@ -53,7 +53,7 @@ export function useMealData<TComboRecipe = string>({
   const isComboMode = selectedCategories.has("Combo");
   const isSubrecipeOnly = filters.additional?.has("isSubrecipe") ?? false;
 
-  const pageSize = isComboMode ? 6 : 4;
+  const pageSize = isComboMode ? 6 : 6;
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 250);


### PR DESCRIPTION
## Developer: Haixin Huang

Closes #171 

### Pull Request Summary

Fixing some bugs on Recipes page
- Layout for combos/recipes, including pagination
- Making combos/recipes page responsive to window resizing and mobile viewing
- Remove servings as filtering option
- Disable negative inputs from recipe form

### Modifications

- src/components/CardGrid.tsx - enable scrolling for combos but disable scrolling for recipes
- src/components/CreateRecipePopUp.tsx - prevent negative numbers on recipe form
- src/components/FilterMenu.tsx - remove servings from filtering menu
- src/components/MealBrowser.tsx - making recipe results responsive
- src/components/RecipeCard.tsx - display # servings
- src/components/RecipePageClient.tsx - make recipe results responsive
- src/hooks/useMealData.ts - set results per page for combo & recipes

### Testing Considerations

Navigate to Recipes page. Make sure that the results are correctly displayed for each food option. Recipes should not exceed size of screen. On the Add New Recipe, user should not be able to enter negative numbers. Adjust window size to see that results adjust layout accordingly.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1915" height="983" alt="image" src="https://github.com/user-attachments/assets/033b3a03-334c-4596-964a-20b36fbcf508" />
<img width="1919" height="977" alt="image" src="https://github.com/user-attachments/assets/9fd9ed6f-5e97-4538-8c43-b2591f57e55f" />

https://github.com/user-attachments/assets/d2df0aab-2258-4deb-bd8a-d71a9df6a6d1

