### PR TITLE
192 misc 1

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,51 +1,72 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import User from "@/database/UserSchema";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const searchParams = req.nextUrl.searchParams;
-  const name = searchParams.get("name")?.trim().toLowerCase();
-  const roleFilter = searchParams.get("role");
-  const sortBy = searchParams.get("sortBy") ?? "";
+  try {
+    const searchParams = req.nextUrl.searchParams;
 
-  const filter: any = {};
-
-  if (name) {
-    filter.name = { $regex: name, $options: "i" };
-  }
-
-  if (roleFilter) {
-    const roles = roleFilter
-      .split(",")
-      .map((r) => r.trim())
+    const name = searchParams.get("name")?.trim();
+    const roles = searchParams
+      .getAll("role")
+      .map((role) => role.trim())
       .filter(Boolean);
-    filter.role = { $in: roles };
+
+    const page = Number(searchParams.get("page") ?? 1);
+    const limit = Number(searchParams.get("limit") ?? 10);
+    const sortBy = searchParams.get("sortBy") ?? "createdDate";
+
+    const filter: any = {};
+
+    if (name) {
+      filter.name = { $regex: name, $options: "i" };
+    }
+
+    if (roles.length > 0) {
+      filter.role = { $in: roles };
+    }
+
+    let sort: Record<string, 1 | -1> = { createdAt: -1 };
+
+    switch (sortBy) {
+      case "lastUpdated":
+        sort = { updatedAt: -1 };
+        break;
+      case "createdDate":
+        sort = { createdAt: -1 };
+        break;
+      case "aToZ":
+        sort = { name: 1 };
+        break;
+      case "zToA":
+        sort = { name: -1 };
+        break;
+    }
+
+    const totalCount = await User.countDocuments(filter);
+
+    let query = User.find(filter)
+      .sort(sort)
+      .skip((page - 1) * limit)
+      .limit(limit);
+
+    if (sortBy === "aToZ" || sortBy === "zToA") {
+      query = query.collation({ locale: "en", strength: 2 });
+    }
+
+    const users = await query;
+
+    return NextResponse.json(
+      {
+        data: users,
+        page,
+        limit,
+        totalPages: Math.ceil(totalCount / limit),
+        totalCount,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    console.error("Error fetching users:", err);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
-
-  let sort: Record<string, 1 | -1> = { createdAt: -1 };
-
-  switch (sortBy) {
-    case "lastUpdated":
-      sort = { updatedAt: -1 };
-      break;
-    case "createdDate":
-      sort = { createdAt: -1 };
-      break;
-    case "aToZ":
-      sort = { name: 1 };
-      break;
-    case "zToA":
-      sort = { name: -1 };
-      break;
-  }
-
-  let query = User.find(filter).sort(sort);
-
-  if (sortBy === "aToZ" || sortBy === "zToA") {
-    query = query.collation({ locale: "en", strength: 2 });
-  }
-
-  const dbUsers = await query;
-
-  return NextResponse.json(dbUsers);
 }

--- a/src/app/permissions/page.tsx
+++ b/src/app/permissions/page.tsx
@@ -15,9 +15,5 @@ export default async function Permissions() {
     redirect("/");
   }
 
-  return (
-    <main>
-      <PermissionsClient />
-    </main>
-  );
+  return <PermissionsClient />;
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,12 +2,11 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, redirect } from "next/navigation";
-import { useClerk, useUser } from "@clerk/nextjs";
+import { useClerk, useUser, SignInButton } from "@clerk/nextjs";
 import { Menu, X } from "lucide-react";
 import { UserRole } from "@/lib/types";
-import { auth } from "@clerk/nextjs/server";
 
 export default function Navbar() {
   const pathname = usePathname();
@@ -147,12 +146,14 @@ export default function Navbar() {
         </div>
       ) : (
         <div className="relative hidden md:block" ref={dropdownRef}>
-          <button
-            onClick={() => redirect("/sign-in")}
-            className="flex items-center gap-3 rounded-lg border border-medium-gray px-4 py-2 hover:bg-light-gray transition-colors cursor-pointer"
-          >
-            Sign In
-          </button>
+          <SignInButton mode="modal">
+            <button
+              type="button"
+              className="flex items-center gap-3 rounded-lg border border-medium-gray px-4 py-2 hover:bg-light-gray transition-colors cursor-pointer"
+            >
+              Sign In
+            </button>
+          </SignInButton>
         </div>
       )}
 
@@ -232,12 +233,15 @@ export default function Navbar() {
             </div>
           ) : (
             <div className="mt-auto flex flex-col gap-2" ref={mobileDropdownRef}>
-              <button
-                onClick={() => redirect("/sign-in")}
-                className="w-full rounded-lg px-3 py-2 text-xs font-medium text-pepper border border-medium-gray hover:bg-light-gray transition-colors"
-              >
-                Sign In
-              </button>
+              <SignInButton mode="modal">
+                <button
+                  type="button"
+                  onClick={() => setDrawerOpen(false)}
+                  className="w-full rounded-lg px-3 py-2 text-xs font-medium text-pepper border border-medium-gray hover:bg-light-gray transition-colors"
+                >
+                  Sign In
+                </button>
+              </SignInButton>
             </div>
           )}
         </div>

--- a/src/components/PermissionsClient.tsx
+++ b/src/components/PermissionsClient.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { UserPerms } from "@/components/IndividualPermission";
 import PermissionsDisplay from "@/components/PermissionsDisplay";
 import SortPermissionsButton from "@/components/SortPermissionsButton";
 import EditPermissionsButton from "@/components/EditPermissionsButton";
 import PermissionsPopUp from "@/components/PermissionsPopUp";
 import SearchBarClient from "@/components/SearchbarClient";
+import PaginationDisplay from "@/components/PaginationDisplay";
 import { SortOption, USER_ROLES, UserRole } from "@/lib/types";
 import RoleToggle from "./RoleToggle";
+
+const PAGE_SIZE = 5;
 
 export default function PermissionsClient() {
   const [usersList, setUsersList] = useState<UserPerms[]>([]);
@@ -19,18 +22,32 @@ export default function PermissionsClient() {
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [selectedRole, setSelectedRole] = useState<Set<UserRole>>(new Set<UserRole>());
   const [sortOption, setSortOption] = useState<SortOption>("createdDate");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
 
     async function loadUsers() {
       try {
-        const parsed = search.trim().toLowerCase();
+        setIsLoading(true);
+
+        const parsed = search.trim();
 
         const params = new URLSearchParams();
-        params.append("name", parsed);
-        params.append("role", Array.from(selectedRole).join(","));
+
+        if (parsed) {
+          params.append("name", parsed);
+        }
+
+        selectedRole.forEach((role) => {
+          params.append("role", role);
+        });
+
         params.append("sortBy", sortOption);
+        params.append("page", currentPage.toString());
+        params.append("limit", PAGE_SIZE.toString());
 
         const res = await fetch(`/api/users?${params.toString()}`, {
           signal: controller.signal,
@@ -40,31 +57,52 @@ export default function PermissionsClient() {
           throw new Error(`Request failed: ${res.status}`);
         }
 
-        const users = await res.json();
-        console.log(users);
-        setUsersList(users);
+        const result = await res.json();
+
+        setUsersList(result.data);
+        setTotalPages(result.totalPages || 1);
       } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+
         console.error("Error fetching users:", err);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
       }
     }
 
     loadUsers();
-  }, [search, selectedRole, sortOption]);
 
-  /* TODO: Eventually the API should receive: search, selectedRoles, currentPage, PAGE_SIZE. */
+    return () => controller.abort();
+  }, [search, selectedRole, sortOption, currentPage]);
 
-  const toggleRole = (category: UserRole) => {
+  const handleSearch = (value: string) => {
+    setSearch(value);
+    setCurrentPage(1);
+  };
+
+  const handleSortChange = (value: SortOption) => {
+    setSortOption(value);
+    setCurrentPage(1);
+  };
+
+  const toggleRole = (role: UserRole) => {
     setSelectedRole((prev) => {
       const next = new Set<UserRole>(prev);
 
-      if (next.has(category)) {
-        next.delete(category);
+      if (next.has(role)) {
+        next.delete(role);
       } else {
-        next.add(category);
+        next.add(role);
       }
 
       return next;
     });
+
+    setCurrentPage(1);
   };
 
   const toggleUserSelection = (user: UserPerms) => {
@@ -123,8 +161,8 @@ export default function PermissionsClient() {
   };
 
   return (
-    <main>
-      <div className="flex flex-col gap-4 px-4 py-5 sm:px-6 lg:px-10">
+    <main className="flex flex-col min-h-0 flex-1">
+      <div className="flex flex-col gap-4 px-4 py-5 sm:px-6 lg:px-10 overflow-hidden">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-lg font-semibold sm:text-xl">Manage Permissions</h1>
           <EditPermissionsButton
@@ -140,15 +178,22 @@ export default function PermissionsClient() {
         </div>
 
         <div className="flex min-w-0 items-center gap-2 sm:gap-3">
-          <SearchBarClient placeholder="Search a user" onSearch={setSearch} />{" "}
-          <SortPermissionsButton align="right" activeType={sortOption} onSortChange={setSortOption} />
+          <SearchBarClient placeholder="Search a user" onSearch={handleSearch} />{" "}
+          <SortPermissionsButton align="right" activeType={sortOption} onSortChange={handleSortChange} />
         </div>
 
-        <div>
+        <div className="flex items-center justify-between gap-3">
           <RoleToggle options={[...USER_ROLES]} selectedRoles={selectedRole} onToggle={toggleRole} />
+
+          <PaginationDisplay
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+            disabled={isLoading}
+          />
         </div>
 
-        <div>
+        <div className="flex flex-col overflow-auto">
           <PermissionsDisplay
             users={usersList}
             editing={isEditing}
@@ -160,19 +205,21 @@ export default function PermissionsClient() {
 
         {isEditing && selectedUsers.length > 0 && <div className="h-36 sm:h-24"></div>}
       </div>
+
       {isEditing && selectedUsers.length > 0 && (
-        <PermissionsPopUp
-          selectedUsers={selectedUsers}
-          setSelectedUsers={setSelectedUsers}
-          onBulkDelete={() => setShowDeleteModal(true)}
-        />
+        <div className="flex flex-col overflow-auto">
+          <PermissionsPopUp
+            selectedUsers={selectedUsers}
+            setSelectedUsers={setSelectedUsers}
+            onBulkDelete={() => setShowDeleteModal(true)}
+          />
+        </div>
       )}
 
       {showDeleteModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 rounded-base">
           <div className="relative p-4 w-full max-w-md">
             <div className="bg-white relative bg-neutral-primary-soft rounded-lg shadow-sm p-4 md:p-6">
-              {/* Close button */}
               <button
                 type="button"
                 className="absolute top-3 right-2.5 text-body bg-transparent hover:bg-neutral-tertiary hover:text-heading rounded-base text-sm w-9 h-9 flex items-center justify-center cursor-pointer"
@@ -181,12 +228,10 @@ export default function PermissionsClient() {
                 ✕
               </button>
 
-              {/* Modal content */}
               <h3 className="text-lg font-semibold text-heading">Delete user?</h3>
 
               <p className="text-sm text-body mt-2">This action cannot be undone.</p>
 
-              {/* Buttons */}
               <div className="flex justify-end gap-2 mt-5">
                 <button
                   className="px-4 py-2 rounded-lg text-white bg-dark-gray hover:bg-medium-gray cursor-pointer"
@@ -211,7 +256,6 @@ export default function PermissionsClient() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 rounded-base">
           <div className="relative p-4 w-full max-w-md">
             <div className="bg-white relative bg-neutral-primary-soft rounded-lg shadow-sm p-4 md:p-6">
-              {/* Close button */}
               <button
                 type="button"
                 className="absolute top-3 right-2.5 text-body bg-transparent hover:bg-neutral-tertiary hover:text-heading rounded-base text-sm w-9 h-9 flex items-center justify-center cursor-pointer"
@@ -220,12 +264,10 @@ export default function PermissionsClient() {
                 ✕
               </button>
 
-              {/* Modal content */}
               <h3 className="text-lg font-semibold text-heading">Save changes?</h3>
 
               <p className="text-sm text-body mt-2">This action cannot be undone.</p>
 
-              {/* Buttons */}
               <div className="flex justify-end gap-2 mt-5">
                 <button
                   className="px-4 py-2 rounded-lg text-white bg-dark-gray hover:bg-medium-gray cursor-pointer"

--- a/src/components/PermissionsDisplay.tsx
+++ b/src/components/PermissionsDisplay.tsx
@@ -14,7 +14,7 @@ export default function PermissionsDisplay({ users, editing = false, onSelect, s
   const otherUsers = users.filter((u) => u._id !== currentUser?.id);
 
   return (
-    <div className="flex flex-col gap-y-3 pt-2 text-black font-montserrat">
+    <div className="flex flex-col gap-y-3 text-black font-montserrat">
       {/* Header */}
       <div className="hidden w-full grid-cols-12 items-center pl-8 pr-6 text-sm font-semibold justify-items-center md:grid">
         <div className="col-span-1"></div>

--- a/src/components/ViewRecipePopUp.tsx
+++ b/src/components/ViewRecipePopUp.tsx
@@ -117,6 +117,12 @@ function formatNutritionValue(value: number, originalServings: number, servings:
   return Number.isInteger(scaled) ? scaled.toString() : scaled.toFixed(1);
 }
 
+function formatScaledQuantity(quantity: number, originalServings: number, servings: ServingsValue) {
+  const scaled = (quantity / Math.max(1, originalServings)) * toPositiveServings(servings);
+
+  return Number.isInteger(scaled) ? scaled.toString() : scaled.toFixed(1);
+}
+
 function getComboNutrition(comboRecipes: RecipeBuckets<Recipe>, comboServing: number): Nutrition {
   const allRecipes = RECIPE_BUCKETS.flatMap((bucket) => comboRecipes[bucket] ?? []);
 
@@ -282,7 +288,9 @@ function RecipeDetails({
             </div>
           ) : null}
 
-          {recipe.subrecipes?.length ? <SubrecipeSection subrecipes={recipe.subrecipes} /> : null}
+          {recipe.subrecipes?.length ? (
+            <SubrecipeSection subrecipes={recipe.subrecipes} servings={servings} originalServings={originalServings} />
+          ) : null}
         </>
       ) : null}
 
@@ -352,7 +360,15 @@ function mergeSubrecipes(subrecipes: SubrecipeIngredient[]): SubrecipeIngredient
   return Array.from(merged.values());
 }
 
-function SubrecipeSection({ subrecipes }: { subrecipes: SubrecipeIngredient[] }) {
+function SubrecipeSection({
+  subrecipes,
+  servings,
+  originalServings,
+}: {
+  subrecipes: SubrecipeIngredient[];
+  servings: ServingsValue;
+  originalServings: number;
+}) {
   const merged = mergeSubrecipes(subrecipes);
 
   const CATEGORY_CONFIG: { key: RecipeCategory; label: string; icon: ReactNode }[] = [
@@ -377,7 +393,9 @@ function SubrecipeSection({ subrecipes }: { subrecipes: SubrecipeIngredient[] })
                 {items.map((sr, i) => (
                   <div key={i} className={`flex items-center gap-1 rounded-md px-2 py-1 ${TAG_STYLES[key]}`}>
                     {sr.recipeName || sr.recipeId}
-                    <span className="text-xs opacity-70 ml-1">×{sr.quantity}</span>
+                    <span className="text-xs opacity-70 ml-1">
+                      ×{formatScaledQuantity(sr.quantity, originalServings, servings)}
+                    </span>
                     <button
                       type="button"
                       onClick={() => window.open(`/recipe?id=${sr.recipeId}`)}
@@ -399,7 +417,9 @@ function SubrecipeSection({ subrecipes }: { subrecipes: SubrecipeIngredient[] })
             {uncategorized.map((sr, i) => (
               <div key={i} className="flex items-center gap-1 rounded-md px-2 py-1 bg-pepper text-white">
                 {sr.recipeName || sr.recipeId}
-                <span className="text-xs opacity-70 ml-1">×{sr.quantity}</span>
+                <span className="text-xs opacity-70 ml-1">
+                  ×{formatScaledQuantity(sr.quantity, originalServings, servings)}
+                </span>
                 <button
                   type="button"
                   onClick={() => window.open(`/recipe?id=${sr.recipeId}`)}

--- a/src/lib/menuPlanningExport.ts
+++ b/src/lib/menuPlanningExport.ts
@@ -674,23 +674,28 @@ function sumNutrition(items: ExportRecipe[]): Nutrition {
 function nutritionValues(nutrition: Partial<Nutrition> | undefined) {
   const calories = numberOrZero(nutrition?.calories);
   const fatPct = numberOrZero(nutrition?.fatPercentage);
+  const saturatedFatPct = numberOrZero(nutrition?.saturatedFatPercentage);
+
   const fatCalories = round((calories * fatPct) / 100);
   const fatGrams = round(fatCalories / 9);
+
+  const saturatedFatCalories = round((calories * saturatedFatPct) / 100);
+  const saturatedFatGrams = round(saturatedFatCalories / 9);
 
   return [
     round(calories),
     round(numberOrZero(nutrition?.sodium)),
     round(numberOrZero(nutrition?.protein)),
+    round(numberOrZero(nutrition?.vitaminC)),
+    round(numberOrZero(nutrition?.vitaminA)),
     "--",
-    "--",
-    round(numberOrZero(nutrition?.fatPercentage)),
     fatGrams,
     fatCalories,
     "--",
-    "--",
+    saturatedFatGrams,
     "--",
     round(numberOrZero(nutrition?.fiber)),
-    "--",
+    round(numberOrZero(nutrition?.calcium)),
     "--",
   ];
 }

--- a/src/lib/menuPlanningExport.ts
+++ b/src/lib/menuPlanningExport.ts
@@ -1,4 +1,4 @@
-import { Nutrition } from "@/lib/types";
+import { Nutrition, NUTRIENT_LABELS } from "@/lib/types";
 
 export type MenuExportFormat = "Display" | "Nutritional";
 
@@ -65,23 +65,10 @@ const NUTRITION_HEADERS = [
   "Item Name",
   "Quantity",
   "Measure",
-  "Cals (kcal)",
-  "Sod (mg)",
-  "Prot (g)",
-  "Vit C (mg)",
-  "Vit A-RAE (mcg)",
-  "Carb (g)",
-  "Fat (g)",
-  "FatCals (kcal)",
-  "TransFat (g)",
-  "SatFat (g)",
-  "Chol (mg)",
-  "TotFib (g)",
-  "Calc (mg)",
-  "Iron (mg)",
+  ...NUTRIENT_LABELS.map((nutrient) => `${nutrient.label} (${nutrient.unit})`),
 ] as const;
 
-const NUTRITION_COLUMN_COUNT = 19;
+const NUTRITION_COLUMN_COUNT = NUTRITION_HEADERS.length + 2;
 
 const DISPLAY_STYLES = {
   date: 8,
@@ -635,69 +622,18 @@ function round(value: number) {
   return Math.round(value * 100) / 100;
 }
 
-function sumNutrition(items: ExportRecipe[]): Nutrition {
-  return items.reduce(
-    (total, item) => ({
-      calories: total.calories + numberOrZero(item.nutritional_info?.calories),
-      sodium: total.sodium + numberOrZero(item.nutritional_info?.sodium),
-      protein: total.protein + numberOrZero(item.nutritional_info?.protein),
-      fatPercentage: total.fatPercentage + numberOrZero(item.nutritional_info?.fatPercentage),
-      saturatedFatPercentage:
-        total.saturatedFatPercentage + numberOrZero(item.nutritional_info?.saturatedFatPercentage),
-      fiber: total.fiber + numberOrZero(item.nutritional_info?.fiber),
-      calcium: total.calcium + numberOrZero(item.nutritional_info?.calcium),
-      magnesium: total.magnesium + numberOrZero(item.nutritional_info?.magnesium),
-      potassium: total.potassium + numberOrZero(item.nutritional_info?.potassium),
-      vitaminA: total.vitaminA + numberOrZero(item.nutritional_info?.vitaminA),
-      vitaminD: total.vitaminD + numberOrZero(item.nutritional_info?.vitaminD),
-      vitaminC: total.vitaminC + numberOrZero(item.nutritional_info?.vitaminC),
-      vitaminB12: total.vitaminB12 + numberOrZero(item.nutritional_info?.vitaminB12),
-    }),
-    {
-      calories: 0,
-      sodium: 0,
-      protein: 0,
-      fatPercentage: 0,
-      saturatedFatPercentage: 0,
-      fiber: 0,
-      calcium: 0,
-      magnesium: 0,
-      potassium: 0,
-      vitaminA: 0,
-      vitaminD: 0,
-      vitaminC: 0,
-      vitaminB12: 0,
-    },
-  );
+function sumNutrition(items: ExportRecipe[]): Partial<Nutrition> {
+  return items.reduce<Partial<Nutrition>>((total, item) => {
+    NUTRIENT_LABELS.forEach(({ key }) => {
+      total[key] = numberOrZero(total[key]) + numberOrZero(item.nutritional_info?.[key]);
+    });
+
+    return total;
+  }, {});
 }
 
 function nutritionValues(nutrition: Partial<Nutrition> | undefined) {
-  const calories = numberOrZero(nutrition?.calories);
-  const fatPct = numberOrZero(nutrition?.fatPercentage);
-  const saturatedFatPct = numberOrZero(nutrition?.saturatedFatPercentage);
-
-  const fatCalories = round((calories * fatPct) / 100);
-  const fatGrams = round(fatCalories / 9);
-
-  const saturatedFatCalories = round((calories * saturatedFatPct) / 100);
-  const saturatedFatGrams = round(saturatedFatCalories / 9);
-
-  return [
-    round(calories),
-    round(numberOrZero(nutrition?.sodium)),
-    round(numberOrZero(nutrition?.protein)),
-    round(numberOrZero(nutrition?.vitaminC)),
-    round(numberOrZero(nutrition?.vitaminA)),
-    "--",
-    fatGrams,
-    fatCalories,
-    "--",
-    saturatedFatGrams,
-    "--",
-    round(numberOrZero(nutrition?.fiber)),
-    round(numberOrZero(nutrition?.calcium)),
-    "--",
-  ];
+  return NUTRIENT_LABELS.map(({ key }) => round(numberOrZero(nutrition?.[key])));
 }
 
 function buildDisplayWorkbook(days: CalendarDayExport[], year: number, monthIndex: number): WorkbookDefinition {


### PR DESCRIPTION
## Developer: Kevin Diaz

Closes #192 

### Pull Request Summary

Sign in button now brings up the google popup, nutritional info download fills in the proper nutrition info, permissions page is paginated, subrecipes are scaled with serving size.

### Modifications

- `api/users/route.ts`: added pagination support
- `permissions/page.ts`: remove double <main> tag (client already has the main tag)
- `components/Navbar.tsx`: made the signin button bring up a popup for the google prompt
- `components/PermissionsClient.tsx`: use API pagination, sorting, and filtering
- `components/PermissionsDisplay.tsx`: removed a bit of padding
- `ViewRecipePopup.tsx`: subrecipe scaled with servings
- `menuPlanningExport.tsx`: uses all nutritional fields from schema

### Testing Considerations

I don't think any of these are complicated changes, I checked them all as I made them.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="2033" height="559" alt="image" src="https://github.com/user-attachments/assets/14dc9514-0788-4ae0-a758-9c139bed14e2" />
<img width="350" height="298" alt="image" src="https://github.com/user-attachments/assets/cb5e0404-c0f7-4c9f-8aee-dca29da11895" />
<img width="1882" height="503" alt="image" src="https://github.com/user-attachments/assets/596a9b0b-b69f-4c4b-be06-e8653d5355ce" />
<img width="1426" height="535" alt="image" src="https://github.com/user-attachments/assets/6b330f25-ff97-4e05-bc10-6ff7035f18b4" />

