### PR TITLE
193 MongoDB and Clerk

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -20,7 +20,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     await connectDB();
     const updatedUser = await User.findOneAndUpdate(
-      { clerkId: id },
+      { _id: id },
       { $set: updates },
       {
         new: true,
@@ -37,7 +37,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (err?.name === "ValidationError" || err?.name === "StrictModeError") {
       return NextResponse.json({ error: "Invalid Data" }, { status: 400 });
     }
-    console.error("Error updating recipe:", err);
+    console.error("Error updating user:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
@@ -50,14 +50,18 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
 
   try {
     await connectDB();
+
+    const user = await User.findOne({ _id: id });
+    const clerkId = user?.clerkId;
+
     const client = await clerkClient();
     try {
-      await client.users.deleteUser(id);
+      await client.users.deleteUser(clerkId);
     } catch (clerkErr) {
       console.error("Clerk Delete Error:", clerkErr);
     }
 
-    const deletedUser = await User.findOneAndDelete({ clerkId: id });
+    const deletedUser = await User.findOneAndDelete({ _id: id });
 
     if (!deletedUser) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });


### PR DESCRIPTION
## Developer: Ida Voong

Closes #193 

### Pull Request Summary

Figure out why users in mongo and clerk aren't in sync

### Modifications

- `src/app/api/users/[id]/route.ts`: Previously, the id was treated as clerkId when it was actually MongoDB id. 

### Testing Considerations

- signing in as new user reflected in both clerk and mongo
- deleting user removes them from both clerk and mongo
- possibly delete all users from both mongo and clerk to start fresh

I think the reason why the users weren't sync in mongo and clerk was because of the delete not working properly. I don't think we need to use webhooks to get them in sync because were doing it manually, but lmk if you think it should still be implemented.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
